### PR TITLE
reflex: Add direct event filtering capability to the consumer

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -27,6 +27,7 @@ type consumer struct {
 	latencyHist        prometheus.Observer
 	filterIncludeTypes []EventType
 	activityKey        string
+	filterEvent        EventFilter
 }
 
 // ConsumerOption will change the behaviour of the consumer
@@ -76,6 +77,14 @@ func WithoutConsumerActivityTTL() ConsumerOption {
 func WithFilterIncludeTypes(evts ...EventType) ConsumerOption {
 	return func(c *consumer) {
 		c.filterIncludeTypes = evts
+	}
+}
+
+// WithEventFilter provides an option to specify which Event values a consumer is interested in.
+// For uninteresting events Consume is never called, and a skipped metric is incremented.
+func WithEventFilter(flt EventFilter) ConsumerOption {
+	return func(c *consumer) {
+		c.filterEvent = flt
 	}
 }
 
@@ -131,8 +140,12 @@ func (c *consumer) Consume(ctx context.Context, ft fate.Fate,
 		ctx = tracing.Inject(ctx, event.Trace)
 	}
 
-	var err error
-	if len(c.filterIncludeTypes) == 0 || IsAnyType(event.Type, c.filterIncludeTypes...) {
+	ok, err := c.filter(event)
+	if err != nil {
+		if !IsExpected(err) {
+			c.errorCounter.Inc()
+		}
+	} else if ok {
 		err = c.fn(ctx, ft, event)
 		if err != nil && !IsExpected(err) {
 			c.errorCounter.Inc()
@@ -145,6 +158,15 @@ func (c *consumer) Consume(ctx context.Context, ft fate.Fate,
 	}
 
 	return err
+}
+
+func (c *consumer) filter(event *Event) (bool, error) {
+	ok := len(c.filterIncludeTypes) == 0 || IsAnyType(event.Type, c.filterIncludeTypes...)
+	var err error
+	if ok && c.filterEvent != nil {
+		ok, err = c.filterEvent(event)
+	}
+	return ok, err
 }
 
 // Reset the consumer, create metrics ready for Consume

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -179,6 +179,7 @@ func TestConsumeWithSkip(t *testing.T) {
 		*consumedCounter++
 		return nil
 	}
+	fltErr := errors.New("filter error")
 	evts := []*Event{
 		{
 			ID:        "1",
@@ -203,6 +204,7 @@ func TestConsumeWithSkip(t *testing.T) {
 		expConsumeCount int
 		expMetricCount  int
 		expSkipCount    float64
+		errs            []error
 	}{
 		{
 			name:            "no include filter provided",
@@ -219,11 +221,49 @@ func TestConsumeWithSkip(t *testing.T) {
 			expSkipCount:    0,
 		},
 		{
+			name:            "nill event filter provided",
+			c:               NewConsumer(consumerName, cFn, WithEventFilter(nil)),
+			expConsumeCount: 3,
+			expMetricCount:  0,
+			expSkipCount:    0,
+		},
+		{
 			name:            "include filter provided",
 			c:               NewConsumer(consumerName, cFn, WithFilterIncludeTypes(eventType(1), eventType(2))),
 			expConsumeCount: 2,
 			expMetricCount:  1,
 			expSkipCount:    1,
+		},
+		{
+			name: "event filter provided",
+			c: NewConsumer(consumerName, cFn, WithEventFilter(func(e *Event) (bool, error) {
+				return e.ID == "1" || e.ID == "2", nil
+			})),
+			expConsumeCount: 2,
+			expMetricCount:  1,
+			expSkipCount:    1,
+		},
+		{
+			name: "include filter and event filter provided",
+			c: NewConsumer(consumerName, cFn, WithFilterIncludeTypes(eventType(1), eventType(2)), WithEventFilter(func(e *Event) (bool, error) {
+				return e.ID == "1", nil
+			})),
+			expConsumeCount: 1,
+			expMetricCount:  1,
+			expSkipCount:    2,
+		},
+		{
+			name: "include filter and event filter errors",
+			c: NewConsumer(consumerName, cFn, WithFilterIncludeTypes(eventType(1), eventType(2)), WithEventFilter(func(e *Event) (bool, error) {
+				if e.ID == "1" {
+					return false, fltErr
+				}
+				return true, nil
+			})),
+			expConsumeCount: 1,
+			expMetricCount:  1,
+			expSkipCount:    1,
+			errs:            []error{fltErr, nil, nil},
 		},
 	}
 
@@ -232,9 +272,13 @@ func TestConsumeWithSkip(t *testing.T) {
 			metrics.ConsumerSkippedEvents.Reset()
 			*consumedCounter = 0
 
-			for _, ev := range evts {
+			for i, ev := range evts {
 				err := tc.c.Consume(ctx, f, ev)
-				jtest.RequireNil(t, err)
+				if tc.errs == nil {
+					jtest.RequireNil(t, err)
+				} else {
+					jtest.Require(t, tc.errs[i], err)
+				}
 			}
 
 			require.Equal(t, tc.expConsumeCount, *consumedCounter)

--- a/filter.go
+++ b/filter.go
@@ -1,0 +1,39 @@
+package reflex
+
+import "errors"
+
+// EventFilter takes a Event and returns true if it should be allowed to be processed or
+// false if it shouldn't. It can error if it fails to determine if the event should be processed.
+type EventFilter func(event *Event) (bool, error)
+
+// AllEventFilters combines all its supplied EventFilter parameters and generates a single EventFilter
+// that return true if all the EventFilter parameters return true and errors if any of them errors.
+func AllEventFilters(efs ...EventFilter) EventFilter {
+	return func(event *Event) (bool, error) {
+		for _, ef := range efs {
+			ok, err := ef(event)
+			if !ok || err != nil {
+				return false, err
+			}
+		}
+		return true, nil
+	}
+}
+
+// AnyEventFilters combines all its supplied EventFilter parameters and generates a single EventFilter
+// that return true if any of the EventFilter parameters return true and otherwise return false together
+// with any combination of errors returned from each of the filters.
+func AnyEventFilters(efs ...EventFilter) EventFilter {
+	return func(event *Event) (bool, error) {
+		var allErr []error = nil
+		for _, ef := range efs {
+			ok, err := ef(event)
+			if err != nil {
+				allErr = append(allErr, err)
+			} else if ok {
+				return true, nil
+			}
+		}
+		return false, errors.Join(allErr...)
+	}
+}

--- a/filter_test.go
+++ b/filter_test.go
@@ -1,0 +1,168 @@
+package reflex
+
+import (
+	"errors"
+	"github.com/luno/jettison/jtest"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var err1 = errors.New("error 1")
+var err2 = errors.New("error 2")
+var err3 = errors.New("error 3")
+
+func trueFilter(err error) EventFilter {
+	return func(event *Event) (bool, error) {
+		return true, err
+	}
+}
+
+func falseFilter(err error) EventFilter {
+	return func(event *Event) (bool, error) {
+		return false, err
+	}
+}
+
+func filters(efs ...EventFilter) []EventFilter {
+	return efs
+}
+
+func TestAllEventFilters(t *testing.T) {
+	tests := []struct {
+		name string
+		efs  []EventFilter
+		ok   bool
+		err  error
+	}{
+		{
+			name: "Nil filters",
+			ok:   true,
+		},
+		{
+			name: "True filter",
+			efs:  filters(trueFilter(nil)),
+			ok:   true,
+		},
+		{
+			name: "False filter",
+			efs:  filters(falseFilter(nil)),
+		},
+		{
+			name: "True Error filter",
+			efs:  filters(trueFilter(err1)),
+			err:  err1,
+		},
+		{
+			name: "False Error filter",
+			efs:  filters(falseFilter(err1)),
+			err:  err1,
+		},
+		{
+			name: "All true filter",
+			efs:  filters(trueFilter(nil), trueFilter(nil), trueFilter(nil)),
+			ok:   true,
+		},
+		{
+			name: "One false filter",
+			efs:  filters(trueFilter(nil), falseFilter(nil), trueFilter(nil)),
+			ok:   false,
+		},
+		{
+			name: "One false One error filter",
+			efs:  filters(trueFilter(err1), falseFilter(nil), trueFilter(nil)),
+			ok:   false,
+			err:  err1,
+		},
+		{
+			name: "Two false No error filter",
+			efs:  filters(falseFilter(nil), falseFilter(err1), trueFilter(nil)),
+			ok:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			evt := &Event{}
+			ok, err := AllEventFilters(tt.efs...)(evt)
+			if tt.err == nil {
+				jtest.RequireNil(t, err)
+			} else {
+				jtest.Require(t, tt.err, err)
+			}
+			require.Equal(t, tt.ok, ok)
+		})
+	}
+}
+
+func TestAnyEventFilters(t *testing.T) {
+	tests := []struct {
+		name string
+		efs  []EventFilter
+		ok   bool
+		err  error
+	}{
+		{
+			name: "Nil filters",
+		},
+		{
+			name: "True filter",
+			efs:  filters(trueFilter(nil)),
+			ok:   true,
+		},
+		{
+			name: "False filter",
+			efs:  filters(falseFilter(nil)),
+		},
+		{
+			name: "True Error filter",
+			efs:  filters(trueFilter(err1)),
+			err:  err1,
+		},
+		{
+			name: "False Error filter",
+			efs:  filters(falseFilter(err1)),
+			err:  err1,
+		},
+		{
+			name: "All true filter",
+			efs:  filters(trueFilter(nil), trueFilter(nil), trueFilter(nil)),
+			ok:   true,
+		},
+		{
+			name: "One false filter",
+			efs:  filters(trueFilter(nil), falseFilter(nil), trueFilter(nil)),
+			ok:   true,
+		},
+		{
+			name: "Two false One error filter",
+			efs:  filters(trueFilter(err1), falseFilter(nil), falseFilter(nil)),
+			err:  err1,
+		},
+		{
+			name: "One false No error filter",
+			efs:  filters(trueFilter(nil), falseFilter(err1), trueFilter(nil)),
+			ok:   true,
+		},
+		{
+			name: "Two false Two error filter",
+			efs:  filters(falseFilter(err1), falseFilter(err2), trueFilter(nil)),
+			ok:   true,
+		},
+		{
+			name: "Two false Three error filter",
+			efs:  filters(falseFilter(err1), falseFilter(err2), trueFilter(err3)),
+			err:  errors.Join(err1, err2, err3),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			evt := &Event{}
+			ok, err := AnyEventFilters(tt.efs...)(evt)
+			if tt.err == nil {
+				jtest.RequireNil(t, err)
+			} else {
+				require.Equal(t, tt.err.Error(), err.Error())
+			}
+			require.Equal(t, tt.ok, ok)
+		})
+	}
+}

--- a/rpatterns/parallel.go
+++ b/rpatterns/parallel.go
@@ -79,7 +79,7 @@ type eventKeyFn func(event *reflex.Event) ([]byte, error)
 
 // EventFilter takes a reflex.Event and returns true if it should be allowed to be processed or
 // false if it shouldn't. It can error if it fails to determine if the event should be processed.
-type EventFilter func(event *reflex.Event) (bool, error)
+type EventFilter reflex.EventFilter
 
 func filterOnHash(m, n int, keyFn eventKeyFn) EventFilter {
 	hsh := fnv.New32()


### PR DESCRIPTION
Still need to add helper to generate an EventFilter from a Metadata ([]byte) deserialiser function and deserialised metadata value filter function but that requires generics and is probably best done in another MR.