### PR TITLE
run: fail early for nil opt being passed in

### DIFF
--- a/api.go
+++ b/api.go
@@ -99,6 +99,12 @@ func (req Spec) Stop() error {
 func NewSpec(stream StreamFunc, cStore CursorStore, consumer Consumer,
 	opts ...StreamOption,
 ) Spec {
+	for _, o := range opts {
+		if o == nil {
+			panic("nil opt passed in")
+		}
+	}
+
 	return Spec{
 		stream:   stream,
 		cStore:   cStore,

--- a/run.go
+++ b/run.go
@@ -43,9 +43,6 @@ func Run(in context.Context, s Spec) error {
 		opts []StreamOption
 	)
 	for _, opt := range s.opts {
-		if opt == nil {
-			panic("nil opt passed in")
-		}
 		var temp StreamOptions
 		opt(&temp)
 		if temp.Lag > 0 {

--- a/run.go
+++ b/run.go
@@ -43,6 +43,9 @@ func Run(in context.Context, s Spec) error {
 		opts []StreamOption
 	)
 	for _, opt := range s.opts {
+		if opt == nil {
+			panic("nil opt passed in")
+		}
 		var temp StreamOptions
 		opt(&temp)
 		if temp.Lag > 0 {


### PR DESCRIPTION
### Changed
- fail early for nil opt being passed in (`opt(&temp)` at `run.go:47`
  - we encountered an issue with a panic when an opt was nil, but it wasn't encountered immediately, so changing run to fail early


Options are:
1. Return error from `Run`
2. Panic from `Run`
3. Validate options earlier - Panic in `NewSpec`, before `Run` (current approach in this MR, func doesn't return an err)
  