### PR TITLE
Remove prefix validation to allow filtering by filenames

### DIFF
--- a/rblob/blob.go
+++ b/rblob/blob.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net/url"
 	"path"
 	"strconv"
 	"strings"
@@ -58,16 +57,6 @@ type Option func(*Bucket)
 func OpenBucket(ctx context.Context, label, urlstr string,
 	opts ...Option,
 ) (*Bucket, error) {
-	u, err := url.Parse(urlstr)
-	if err != nil {
-		return nil, errors.Wrap(err, "parse url string")
-	}
-
-	prefix := u.Query().Get("prefix")
-	if prefix != "" && !strings.HasSuffix(prefix, "/") {
-		return nil, errors.New("prefix should end with '/'")
-	}
-
 	bucket, err := blob.OpenBucket(ctx, urlstr)
 	if err != nil {
 		return nil, err

--- a/rblob/blob_test.go
+++ b/rblob/blob_test.go
@@ -24,6 +24,7 @@ func TestStreamAll(t *testing.T) {
 	tests := []struct {
 		Name     string
 		Path     string
+		Prefix   string
 		After    string
 		Expect   int
 		IDOffset int
@@ -58,6 +59,26 @@ func TestStreamAll(t *testing.T) {
 			Expect:   3,
 			IDOffset: 4,
 		},
+		{
+			Name:     "prefix with slash",
+			Path:     "2020",
+			Prefix:   "01/",
+			Expect:   3,
+			IDOffset: 3,
+		},
+		{
+			Name:   "prefix without slash",
+			Path:   "2021",
+			Prefix: "Test-2021-01-01",
+			Expect: 3,
+		},
+		{
+			Name:     "prefix without slash and offset",
+			Path:     "2021",
+			Prefix:   "Test-2021-01-02",
+			Expect:   2,
+			IDOffset: 3,
+		},
 	}
 
 	dir, err := os.Getwd()
@@ -66,6 +87,9 @@ func TestStreamAll(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
 			url := "file:///" + path.Join(dir, "testdata", test.Path)
+			if test.Prefix != "" {
+				url += "?prefix=" + test.Prefix
+			}
 
 			bucket, err := rblob.OpenBucket(context.Background(), "", url)
 			require.NoError(t, err)

--- a/rblob/testdata/2021/Test-2021-01-01-05-15-56-1to3
+++ b/rblob/testdata/2021/Test-2021-01-01-05-15-56-1to3
@@ -1,0 +1,1 @@
+{"id":1,"field":"value1"}{"id":2,"field":"value2"}{"id":3,"field":"value3"}

--- a/rblob/testdata/2021/Test-2021-01-02-05-15-56-4to5
+++ b/rblob/testdata/2021/Test-2021-01-02-05-15-56-4to5
@@ -1,0 +1,1 @@
+{"id":4,"field":"value4"}{"id":5,"field":"value5"}


### PR DESCRIPTION
This change removes the strict validation that enforced prefixes to end with a '/'. Previously, this validation forced users to only open and search within directories. The modification allows for more flexible use of prefixes, enabling filtering by specific filenames when opening a bucket with a URL.