### PR TITLE
github: Update branch push to only run on main

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,7 +2,7 @@ name: Go
 
 on:
   push:
-    branches: [ "**" ]
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 


### PR DESCRIPTION
### Changed
- Update branch push to only run on main, so we don't have each CI run going twice