### PR TITLE
rcache: Allow disabling of rcache

### DIFF
--- a/rsql/rcache.go
+++ b/rsql/rcache.go
@@ -22,6 +22,18 @@ type rcache struct {
 	limit  int
 }
 
+// enabled is the source of truth whether the rcache is enabled or not.
+var enabled bool
+
+func init() {
+	enabled = true
+}
+
+// DisableCache results in all loading going straight through to the underlying loader.
+func DisableCache() {
+	enabled = false
+}
+
 // newRCache returns a new read-through cache.
 func newRCache(loader loader, name string) *rcache {
 	return &rcache{
@@ -62,7 +74,8 @@ func (c *rcache) tailUnsafe() int64 {
 func (c *rcache) Load(ctx context.Context, dbc *sql.DB,
 	prev int64, lag time.Duration,
 ) ([]*reflex.Event, error) {
-	if res, ok := c.maybeHit(prev+1, lag); ok {
+	res, ok := c.maybeHit(prev+1, lag)
+	if enabled && ok {
 		rcacheHitsCounter.WithLabelValues(c.name).Inc()
 		return res, nil
 	}
@@ -112,7 +125,8 @@ func (c *rcache) readThrough(ctx context.Context, dbc *sql.DB,
 	defer c.mu.Unlock()
 
 	// Recheck cache after waiting for lock
-	if res, ok := c.maybeHitUnsafe(prev+1, lag); ok {
+	res, ok := c.maybeHitUnsafe(prev+1, lag)
+	if enabled && ok {
 		return res, nil
 	}
 

--- a/rsql/rcache_test.go
+++ b/rsql/rcache_test.go
@@ -64,7 +64,9 @@ func TestGap(t *testing.T) {
 
 func TestRCache(t *testing.T) {
 	tests := []struct {
-		name    string
+		name     string
+		disabled bool
+
 		add1    int
 		q1      int64
 		len1    int
@@ -98,6 +100,20 @@ func TestRCache(t *testing.T) {
 			len2:    2,
 			total2:  1,
 			q2Count: 1,
+			cLen2:   2,
+		},
+		{
+			name:     "disabled-miss-hit",
+			disabled: true,
+			add1:     2,
+			len1:     2,
+			total1:   1,
+			q1Count:  1,
+			cLen1:    2,
+
+			len2:    2,
+			total2:  2,
+			q2Count: 2,
 			cLen2:   2,
 		},
 		{
@@ -161,6 +177,12 @@ func TestRCache(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			if test.disabled {
+				DisableCache()
+				t.Cleanup(func() {
+					enabled = true
+				})
+			}
 			q := newQ()
 			c := newRCache(q.Load, "test")
 			c.limit = rCacheLimit

--- a/rsql/rcache_test.go
+++ b/rsql/rcache_test.go
@@ -180,7 +180,7 @@ func TestRCache(t *testing.T) {
 			if test.disabled {
 				DisableCache()
 				t.Cleanup(func() {
-					enabled = true
+					cacheDisabled = false
 				})
 			}
 			q := newQ()


### PR DESCRIPTION
This allows the ability to disable the cache at runtime. Primarily can be used for testing but can also have applications outside of testing. This change would force the behaviour of RCache to allow all calls to read through to the underlying loader.