### PR TITLE
rsql: Add common database connection interface

### DIFF
--- a/rsql/errorstable.go
+++ b/rsql/errorstable.go
@@ -11,14 +11,14 @@ import (
 )
 
 // ErrorInserter abstracts the insertion of an error into a sql table.
-type ErrorInserter func(ctx context.Context, tx *sql.Tx, consumer, eventID, errMsg string, errStatus reflex.ErrorStatus) (string, error)
+type ErrorInserter func(ctx context.Context, dbc DBC, consumer, eventID, errMsg string, errStatus reflex.ErrorStatus) (string, error)
 
 // ErrorEventInserter abstracts the insertion of an event into a sql table including providing a notification capability.
-type ErrorEventInserter func(ctx context.Context, tx *sql.Tx, foreignID string, typ reflex.EventType, metadata []byte) (NotifyFunc, error)
+type ErrorEventInserter func(ctx context.Context, dbc DBC, foreignID string, typ reflex.EventType, metadata []byte) (NotifyFunc, error)
 
 func doNothing() {}
 
-func nullEventInserter(_ context.Context, _ *sql.Tx, _ string, _ reflex.EventType, _ []byte) (NotifyFunc, error) {
+func nullEventInserter(_ context.Context, _ DBC, _ string, _ reflex.EventType, _ []byte) (NotifyFunc, error) {
 	return doNothing, nil
 }
 

--- a/rsql/eventstable_test.go
+++ b/rsql/eventstable_test.go
@@ -2,7 +2,6 @@ package rsql_test
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"math/rand"
 	"sync"
@@ -517,8 +516,8 @@ func TestInMemNotifier(t *testing.T) {
 }
 
 func TestCloneInserter(t *testing.T) {
-	makeInserter := func(i *int) func(context.Context, *sql.Tx, string, reflex.EventType, []byte) error {
-		return func(context.Context, *sql.Tx, string, reflex.EventType, []byte) error {
+	makeInserter := func(i *int) func(context.Context, rsql.DBC, string, reflex.EventType, []byte) error {
+		return func(context.Context, rsql.DBC, string, reflex.EventType, []byte) error {
 			*i++
 			return nil
 		}

--- a/rsql/eventstableint.go
+++ b/rsql/eventstableint.go
@@ -2,7 +2,6 @@ package rsql
 
 import (
 	"context"
-	"database/sql"
 	"strconv"
 
 	"github.com/luno/reflex"
@@ -19,18 +18,18 @@ type EventsTableInt struct {
 }
 
 // Insert works as EventsTable.Insert except that foreign id is an int64.
-func (e *EventsTableInt) Insert(ctx context.Context, tx *sql.Tx, foreignID int64,
+func (e *EventsTableInt) Insert(ctx context.Context, dbc DBC, foreignID int64,
 	typ reflex.EventType,
 ) (NotifyFunc, error) {
-	return e.EventsTable.Insert(ctx, tx, strconv.FormatInt(foreignID, 10), typ)
+	return e.EventsTable.Insert(ctx, dbc, strconv.FormatInt(foreignID, 10), typ)
 }
 
 // InsertWithMetadata works as EventsTable.InsertWithMetadata except
 // that foreign id is an int64.
-func (e *EventsTableInt) InsertWithMetadata(ctx context.Context, tx *sql.Tx, foreignID int64,
+func (e *EventsTableInt) InsertWithMetadata(ctx context.Context, dbc DBC, foreignID int64,
 	typ reflex.EventType, metadata []byte,
 ) (NotifyFunc, error) {
-	return e.EventsTable.InsertWithMetadata(ctx, tx,
+	return e.EventsTable.InsertWithMetadata(ctx, dbc,
 		strconv.FormatInt(foreignID, 10), typ, metadata)
 }
 

--- a/rsql/helpers_test.go
+++ b/rsql/helpers_test.go
@@ -2,7 +2,6 @@ package rsql_test
 
 import (
 	"context"
-	"database/sql"
 	"strconv"
 	"testing"
 	"time"
@@ -19,39 +18,27 @@ func (t testEventType) ReflexType() int {
 	return int(t)
 }
 
-func insertTestEvent(dbc *sql.DB, table *rsql.EventsTable, foreignID string, typ reflex.EventType) error {
-	tx, err := dbc.Begin()
-	if err != nil {
-		return err
-	}
-	defer tx.Rollback()
-
-	notify, err := table.Insert(context.Background(), tx, foreignID, typ)
+func insertTestEvent(dbc rsql.DBC, table *rsql.EventsTable, foreignID string, typ reflex.EventType) error {
+	notify, err := table.Insert(context.Background(), dbc, foreignID, typ)
 	if err != nil {
 		return err
 	}
 	defer notify()
 
-	return tx.Commit()
+	return nil
 }
 
-func insertTestEventMeta(dbc *sql.DB, table *rsql.EventsTable, foreignID string,
+func insertTestEventMeta(dbc rsql.DBC, table *rsql.EventsTable, foreignID string,
 	typ reflex.EventType, metadata []byte,
 ) error {
-	tx, err := dbc.Begin()
-	if err != nil {
-		return err
-	}
-	defer tx.Rollback()
-
-	notify, err := table.InsertWithMetadata(context.Background(), tx, foreignID,
+	notify, err := table.InsertWithMetadata(context.Background(), dbc, foreignID,
 		typ, metadata)
 	if err != nil {
 		return err
 	}
 	defer notify()
 
-	return tx.Commit()
+	return nil
 }
 
 func i2s(i int) string {

--- a/rsql/mock_test.go
+++ b/rsql/mock_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/luno/reflex"
+	"github.com/luno/reflex/rsql"
 )
 
 type mockNotifier struct {
@@ -68,7 +69,7 @@ func (m *mockTable) Load(_ context.Context, _ *sql.DB, prevCursor int64,
 	return nil, nil
 }
 
-func (m *mockTable) Insert(_ context.Context, _ *sql.Tx,
+func (m *mockTable) Insert(_ context.Context, _ rsql.DBC,
 	foreignID string, typ reflex.EventType, metadata []byte,
 ) error {
 	m.events = append(m.events, &reflex.Event{
@@ -88,7 +89,7 @@ type mockErrorTable struct {
 }
 
 func (m *mockErrorTable) errorInserter(_ context.Context,
-	_ *sql.Tx, _, _, _ string, _ reflex.ErrorStatus,
+	_ rsql.DBC, _, _, _ string, _ reflex.ErrorStatus,
 ) (string, error) {
 	m.id++
 	return strconv.FormatInt(m.id, 10), nil


### PR DESCRIPTION
The aim of this PR is to allow the insertion of events without starting a transaction. This allows rsql to be used outside of the use case of updating a stateful table along with an event to represent that change.