### PR TITLE
sonar: Update deprecated action

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -43,4 +43,4 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         if: github.event.pull_request.head.repo.full_name == github.repository || env.SONAR_TOKEN != ''
-        uses: SonarSource/sonarqube-scan-action@master
+        uses: SonarSource/sonarqube-scan-action@v5.1.0

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -40,6 +40,7 @@ jobs:
           DB_EXAMPLE_SERVER_URI: "root@tcp(localhost:${{ job.services.mysql.ports[3306] }})/example"
 
       - name: Upload coverage reports to Sonar
-        uses: sonarsource/sonarcloud-github-action@master
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        if: github.event.pull_request.head.repo.full_name == github.repository || env.SONAR_TOKEN != ''
+        uses: SonarSource/sonarqube-scan-action@master


### PR DESCRIPTION
This PR replaces the deprecated `sonarsource/sonarcloud-github-action@master` with the recommended `SonarSource/sonarqube-scan-action@master` as suggested in the CI warning message.

The warning message was:
```
::warning title=SonarScanner::This action is deprecated and will be removed in a future release. Please use the sonarqube-scan-action action instead. The sonarqube-scan-action is a drop-in replacement for this action.
```

This change follows the same pattern as used in luno-go, including the conditional check to only run the SonarQube scan when:
- The pull request comes from the same repository (not a fork), or
- The SONAR_TOKEN environment variable is available

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the workflow for uploading coverage reports to Sonar with improved action and execution conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->