### PR TITLE
go: Update Go version to 1.24.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/luno/reflex
 
-go 1.21
+go 1.24.3
 
 require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.35.0


### PR DESCRIPTION
This PR updates the Go version in [`go.mod`](go.mod ) from 1.21 to 1.24.3.

## Changes
- Updated `go` directive in [`go.mod`](go.mod ) from `go 1.21` to `go 1.24.3`

## Rationale
- Go 1.24.3 is the latest patch release of Go 1.24
- This ensures the project uses modern Go features and receives the latest security updates
- Aligns with other Luno repositories that are already using Go 1.24.x

## Testing
The change should be backward compatible as it only updates the minimum required Go version.