### PR TITLE
github/workflows: Use Go version in go.mod rather than static version

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version-file: 'go.mod'
 
       - name: Generate Sonar Report
         run: go test -coverpkg=./... -coverprofile=coverage.out -json ./... > sonar-report.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         mysql: [ 'mysql:8' ]
-        go: [ '1.23', '1' ]
+        go: [ '1.24', '1' ]
 
     services:
       mysql:


### PR DESCRIPTION
Update GitHub Actions workflow to use standardized Go versions ['1.24', '1'] instead of ['1.23', '1'].

This change:
- Uses Go 1.24 as the specific version for testing
- Uses Go '1' to always test against the latest stable version
- Removes older Go version (1.23) that is no longer needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Continuous integration now reads the Go version from the project configuration, ensuring automatic alignment across build and analysis steps.
  - Test matrix updated to use Go 1.24, improving coverage against the latest supported toolchain.
  - These updates enhance consistency and reduce maintenance overhead without impacting application behaviour for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->