### PR TITLE
fix: add jettison error codes to sentinel errors for Is() matching

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -26,7 +26,7 @@ var (
 	cancelProto   = status.FromContextError(context.Canceled).Proto()
 	deadlineProto = status.FromContextError(context.DeadlineExceeded).Proto()
 
-	filterErr = errors.New(filterErrMsg)
+	filterErr = errors.New(filterErrMsg, j.C("ERR_cbdf33be2dcc7a33"))
 )
 
 // IsStoppedErr checks whether err is an ErrStopped
@@ -60,5 +60,5 @@ func IsFilterErr(err error) bool {
 }
 
 func asFilterErr(err error) error {
-	return errors.Wrap(err, filterErrMsg)
+	return errors.Wrap(err, filterErrMsg, j.C("ERR_cbdf33be2dcc7a33"))
 }

--- a/filters/metadata.go
+++ b/filters/metadata.go
@@ -15,11 +15,14 @@ type (
 const (
 	deserializationErrMsg     = "deserialization failed"
 	metadataEventFilterErrMsg = "cannot make a MetadataEventFilter from a nil Deserializer or DataFilter"
+
+	metadataEventFilterErrCode = "ERR_1a5f8c3e7b2d4f09"
+	deserializationErrCode     = "ERR_7e3f5b8a1c4d2e96"
 )
 
 var (
-	metadataEventFilterErr = errors.New(metadataEventFilterErrMsg, j.C("ERR_1a5f8c3e7b2d4f09"))
-	deserializationErr     = errors.New(deserializationErrMsg, j.C("ERR_7e3f5b8a1c4d2e96"))
+	metadataEventFilterErr = errors.New(metadataEventFilterErrMsg, j.C(metadataEventFilterErrCode))
+	deserializationErr     = errors.New(deserializationErrMsg, j.C(deserializationErrCode))
 )
 
 func MetadataEventFilter[T any](ds Deserializer[T], flt DataFilter[T]) (reflex.EventFilter, error) {
@@ -45,7 +48,7 @@ func IsDeserializationErr(err error) bool {
 }
 
 func asDeserializationErr(err error) error {
-	return errors.Wrap(err, deserializationErrMsg, j.C("ERR_7e3f5b8a1c4d2e96"))
+	return errors.Wrap(err, deserializationErrMsg, j.C(deserializationErrCode))
 }
 
 // IsMetadataEventFilterErr returns true if the error occurred during construction of a MetadataEventFilter.
@@ -54,6 +57,6 @@ func IsMetadataEventFilterErr(err error) bool {
 }
 
 func makeMetadataEventFilterErr(ol ...errors.Option) error {
-	ol = append(ol, j.C("ERR_1a5f8c3e7b2d4f09"))
+	ol = append(ol, j.C(metadataEventFilterErrCode))
 	return errors.New(metadataEventFilterErrMsg, ol...)
 }

--- a/filters/metadata.go
+++ b/filters/metadata.go
@@ -18,8 +18,8 @@ const (
 )
 
 var (
-	metadataEventFilterErr = errors.New(metadataEventFilterErrMsg)
-	deserializationErr     = errors.New(deserializationErrMsg)
+	metadataEventFilterErr = errors.New(metadataEventFilterErrMsg, j.C("ERR_1a5f8c3e7b2d4f09"))
+	deserializationErr     = errors.New(deserializationErrMsg, j.C("ERR_7e3f5b8a1c4d2e96"))
 )
 
 func MetadataEventFilter[T any](ds Deserializer[T], flt DataFilter[T]) (reflex.EventFilter, error) {
@@ -45,7 +45,7 @@ func IsDeserializationErr(err error) bool {
 }
 
 func asDeserializationErr(err error) error {
-	return errors.Wrap(err, deserializationErrMsg)
+	return errors.Wrap(err, deserializationErrMsg, j.C("ERR_7e3f5b8a1c4d2e96"))
 }
 
 // IsMetadataEventFilterErr returns true if the error occurred during construction of a MetadataEventFilter.
@@ -54,5 +54,6 @@ func IsMetadataEventFilterErr(err error) bool {
 }
 
 func makeMetadataEventFilterErr(ol ...errors.Option) error {
+	ol = append(ol, j.C("ERR_1a5f8c3e7b2d4f09"))
 	return errors.New(metadataEventFilterErrMsg, ol...)
 }

--- a/filters/metadata_test.go
+++ b/filters/metadata_test.go
@@ -91,7 +91,7 @@ func TestMetadataEventFilter(t *testing.T) {
 		},
 		{
 			name: "Data Filter errors",
-			e:    &reflex.Event{MetaData: []byte("metadata value")},
+			e:    &reflex.Event{MetaData: m},
 			ds: func(x *testing.T) Deserializer[string] {
 				return func(b []byte) (string, error) { require.Equal(x, m, b); return string(b), nil }
 			},
@@ -102,7 +102,7 @@ func TestMetadataEventFilter(t *testing.T) {
 		},
 		{
 			name: "Exclude",
-			e:    &reflex.Event{MetaData: []byte("metadata value")},
+			e:    &reflex.Event{MetaData: m},
 			ds: func(x *testing.T) Deserializer[string] {
 				return func(b []byte) (string, error) { require.Equal(x, m, b); return string(b), nil }
 			},
@@ -112,7 +112,7 @@ func TestMetadataEventFilter(t *testing.T) {
 		},
 		{
 			name: "Include",
-			e:    &reflex.Event{MetaData: []byte("metadata value")},
+			e:    &reflex.Event{MetaData: m},
 			ds: func(x *testing.T) Deserializer[string] {
 				return func(b []byte) (string, error) { require.Equal(x, m, b); return string(b), nil }
 			},
@@ -137,6 +137,7 @@ func TestMetadataEventFilter(t *testing.T) {
 }
 
 func TestIsDeserializationErr(t *testing.T) {
+	const otherErrMsg = "other error"
 	tests := []struct {
 		name string
 		err  error
@@ -147,7 +148,7 @@ func TestIsDeserializationErr(t *testing.T) {
 		},
 		{
 			name: "not deserialization error",
-			err:  errors.New("other error"),
+			err:  errors.New(otherErrMsg),
 		},
 		{
 			name: "direct deserialization error",
@@ -156,12 +157,12 @@ func TestIsDeserializationErr(t *testing.T) {
 		},
 		{
 			name: "indirect deserialization error",
-			err:  errors.Wrap(deserializationErr, "other error"),
+			err:  errors.Wrap(deserializationErr, otherErrMsg),
 			want: true,
 		},
 		{
 			name: "converted deserialization error",
-			err:  asDeserializationErr(errors.New("other error")),
+			err:  asDeserializationErr(errors.New(otherErrMsg)),
 			want: true,
 		},
 		{

--- a/filters/metadata_test.go
+++ b/filters/metadata_test.go
@@ -159,7 +159,7 @@ func TestIsDeserializationErr(t *testing.T) {
 		{
 			name: "constructed deserialization error",
 			err:  errors.New(deserializationErrMsg),
-			want: true,
+			want: false,
 		},
 	}
 	for _, tt := range tests {

--- a/filters/metadata_test.go
+++ b/filters/metadata_test.go
@@ -52,6 +52,14 @@ func TestMakeMetadataEventFilter(t *testing.T) {
 func TestMetadataEventFilter(t *testing.T) {
 	d := "metadata value"
 	m := []byte(d)
+
+	// Define errors once so the same pointer is used in both the closures
+	// and the expected-error slices. jettison's errors.Is uses pointer identity
+	// for errors without a j.C code, so a fresh errors.New in the err slice
+	// would never match.
+	badMetadataErr := errors.New("bad metadata")
+	badFilterErr := errors.New("bad filter")
+
 	type testCase struct {
 		name string
 		e    *reflex.Event
@@ -74,12 +82,12 @@ func TestMetadataEventFilter(t *testing.T) {
 			name: "Deserializer errors",
 			e:    &reflex.Event{MetaData: m},
 			ds: func(x *testing.T) Deserializer[string] {
-				return func(b []byte) (string, error) { require.Equal(x, m, b); return string(b), errors.New("bad metadata") }
+				return func(b []byte) (string, error) { require.Equal(x, m, b); return string(b), badMetadataErr }
 			},
 			flt: func(x *testing.T) DataFilter[string] {
 				return func(s string) (bool, error) { require.Fail(x, "should not be reached"); return true, nil }
 			},
-			err: []error{deserializationErr, errors.New("bad metadata")},
+			err: []error{deserializationErr, badMetadataErr},
 		},
 		{
 			name: "Data Filter errors",
@@ -88,9 +96,9 @@ func TestMetadataEventFilter(t *testing.T) {
 				return func(b []byte) (string, error) { require.Equal(x, m, b); return string(b), nil }
 			},
 			flt: func(x *testing.T) DataFilter[string] {
-				return func(s string) (bool, error) { require.Equal(x, d, s); return true, errors.New("bad filter") }
+				return func(s string) (bool, error) { require.Equal(x, d, s); return true, badFilterErr }
 			},
-			err: []error{errors.New("bad filter")},
+			err: []error{badFilterErr},
 		},
 		{
 			name: "Exclude",

--- a/rpatterns/batch.go
+++ b/rpatterns/batch.go
@@ -22,7 +22,13 @@ type batchEvent struct {
 
 const minWait = time.Millisecond * 100
 
-var ErrBatchState = errors.New("batch error state", j.C("ERR_b3053f5f1a3ecd23"))
+var (
+	ErrBatchState = errors.New("batch error state", j.C("ERR_b3053f5f1a3ecd23"))
+
+	// ErrInvalidBatchConfig is returned when a BatchConsumer is configured with
+	// both batchPeriod and batchLen set to zero.
+	ErrInvalidBatchConfig = errors.New("batchPeriod or batchLen must be non-zero", j.C("ERR_f4a2c8e7b1d53f90"))
+)
 
 // BatchConsumer provides a reflex consumer that buffers events
 // and flushes a batch to the consume function when either
@@ -95,7 +101,7 @@ func (c *BatchConsumer) Stop() error {
 // enqueue adds the event to the buffer or returns error if batch needs to be reset.
 func (c *BatchConsumer) enqueue(ctx context.Context, e *AckEvent) error {
 	if c.flushPeriod == 0 && c.flushLen == 0 {
-		return errors.New("batchPeriod or batchLen must be non-zero")
+		return ErrInvalidBatchConfig
 	}
 
 	// Add event to batch queue

--- a/rpatterns/batch_test.go
+++ b/rpatterns/batch_test.go
@@ -17,6 +17,12 @@ import (
 	"github.com/luno/reflex/rpatterns"
 )
 
+const (
+	msgEventAlreadyProcessed = "event id already processed"
+	msgTestTimedOut          = "test timed out"
+	msgEventNotProcessed     = "event id %d not processed"
+)
+
 func TestRunBatchConsumer(t *testing.T) {
 	tests := []struct {
 		name            string
@@ -301,7 +307,7 @@ func TestContextCancelled(t *testing.T) {
 			}
 			for _, b := range batch {
 				_, ok := processTracker[b.IDInt()]
-				assert.False(t, ok, "event id already processed", b.ID)
+				assert.False(t, ok, msgEventAlreadyProcessed, b.ID)
 
 				processTracker[b.IDInt()] = true
 				for _, can := range cancelCtxEvents {
@@ -341,7 +347,7 @@ func TestContextCancelled(t *testing.T) {
 		case <-chDone:
 			isDone = true
 		case <-time.After(time.Second * 5):
-			assert.Fail(t, "test timed out")
+			assert.Fail(t, msgTestTimedOut)
 			isDone = true
 		}
 
@@ -353,7 +359,7 @@ func TestContextCancelled(t *testing.T) {
 	for idx := 1; idx <= events.Max; idx++ {
 		_, ok := processTracker[int64(idx)]
 		if !ok {
-			assert.Equal(t, true, ok, fmt.Sprintf("event id %d not processed", idx))
+			assert.Equal(t, true, ok, fmt.Sprintf(msgEventNotProcessed, idx))
 		}
 	}
 }
@@ -377,7 +383,7 @@ func TestBatchPeriod(t *testing.T) {
 		func(ctx context.Context, batch rpatterns.Batch) error {
 			for _, b := range batch {
 				_, ok := processTracker[b.IDInt()]
-				assert.False(t, ok, "event id already processed", b.ID)
+				assert.False(t, ok, msgEventAlreadyProcessed, b.ID)
 
 				processTracker[b.IDInt()] = true
 				if b.IDInt() == int64(events.Max) {
@@ -400,13 +406,13 @@ func TestBatchPeriod(t *testing.T) {
 	select {
 	case <-chDone:
 	case <-time.After(time.Second * 5):
-		assert.Fail(t, "test timed out")
+		assert.Fail(t, msgTestTimedOut)
 	}
 
 	for idx := 1; idx <= events.Max; idx++ {
 		_, ok := processTracker[int64(idx)]
 		if !ok {
-			assert.Equal(t, true, ok, fmt.Sprintf("event id %d not processed", idx))
+			assert.Equal(t, true, ok, fmt.Sprintf(msgEventNotProcessed, idx))
 		}
 	}
 }
@@ -448,7 +454,7 @@ func TestBatchErrorState(t *testing.T) {
 				defer tMu.Unlock()
 				for _, b := range batch {
 					_, ok := processTracker[b.IDInt()]
-					assert.False(t, ok, "event id already processed", b.ID)
+					assert.False(t, ok, msgEventAlreadyProcessed, b.ID)
 
 					processTracker[b.IDInt()] = true
 				}
@@ -474,7 +480,7 @@ func TestBatchErrorState(t *testing.T) {
 	case err := <-chErr:
 		assert.True(t, errors.Is(err, rpatterns.ErrBatchState))
 	case <-time.After(time.Second * 5):
-		assert.Fail(t, "test timed out")
+		assert.Fail(t, msgTestTimedOut)
 	}
 
 	// Cursor would be on event 2 which is the one that triggers the ErrBatchState
@@ -492,7 +498,7 @@ func TestBatchErrorState(t *testing.T) {
 		time.Sleep(time.Millisecond * 100) // Wait for last event to process since it's a background process
 		// Batch recovered
 	case <-time.After(time.Second * 5):
-		assert.Fail(t, "test timed out")
+		assert.Fail(t, msgTestTimedOut)
 	}
 
 	for idx := 1; idx <= events.Max; idx++ {
@@ -500,7 +506,7 @@ func TestBatchErrorState(t *testing.T) {
 		_, ok := processTracker[int64(idx)]
 		tMu.Unlock()
 		if !ok {
-			assert.Equal(t, true, ok, fmt.Sprintf("event id %d not processed", idx))
+			assert.Equal(t, true, ok, fmt.Sprintf(msgEventNotProcessed, idx))
 		}
 	}
 }

--- a/rpatterns/batch_test.go
+++ b/rpatterns/batch_test.go
@@ -105,7 +105,6 @@ func TestRunBatchConsumer(t *testing.T) {
 }
 
 func TestReset(t *testing.T) {
-	recvEndErr := errors.New("recv error")
 	tests := []struct {
 		name       string
 		batchLen   int
@@ -146,13 +145,13 @@ func TestReset(t *testing.T) {
 			spec := rpatterns.NewBatchSpec(b.Stream, consumer)
 			ctx := context.Background()
 			err := reflex.Run(ctx, spec)
-			jtest.Assert(t, recvEndErr, err)
+			jtest.Assert(t, errEvents, err)
 
 			events = ItoEList(tt.passEvents...)
 			b.events = events
 
 			err = reflex.Run(ctx, spec)
-			jtest.Assert(t, recvEndErr, err)
+			jtest.Assert(t, errEvents, err)
 		})
 	}
 }

--- a/rpatterns/batch_test.go
+++ b/rpatterns/batch_test.go
@@ -170,7 +170,7 @@ func TestInvalidConfig(t *testing.T) {
 	spec := rpatterns.NewBatchSpec(b.Stream, consumer)
 	ctx := context.Background()
 	err := reflex.Run(ctx, spec)
-	jtest.Assert(t, errors.New("batchPeriod or batchLen must be non-zero"), err)
+	jtest.Assert(t, rpatterns.ErrInvalidBatchConfig, err)
 }
 
 type EventList struct {


### PR DESCRIPTION
## Problem

The jettison library (bumped to `v0.0.0-20260328151427-502b299c2358` on main) removed the `JettisonError` type and its message-based fallback in `errors.Is`. Sentinel errors without a `j.C("code")` annotation now only match by pointer identity.

Several sentinel errors in this repo had no codes, and their wrapper constructors created new error instances (different pointers), so `errors.Is` stopped finding the sentinel in the chain:

| Sentinel | Affected check |
|----------|----------------|
| `filterErr` | `IsFilterErr(asFilterErr(err))` |
| `deserializationErr` | `IsDeserializationErr(asDeserializationErr(err))` |
| `metadataEventFilterErr` | `IsMetadataEventFilterErr(makeMetadataEventFilterErr(...))` |

This caused CI failures in the `sonar` workflow on `main` (pre-existing, not introduced by any PR).

## Fix

- Add `j.C("ERR_...")` codes to each sentinel error and its wrapper/constructor so jettison's code-based matching finds the sentinel in the error chain.
- `filters/metadata_test.go`: mark the `"constructed deserialization error"` test case as `want: false` — an externally-constructed error with the same message should not satisfy `IsDeserializationErr`, and the old `want: true` only worked due to the message-based fallback that no longer exists.
- `rpatterns/batch_test.go` (`TestReset`): replace `recvEndErr := errors.New("recv error")` with `errEvents` (which has a code), since `errEvents` is what the mock actually returns and what ends up in the error chain.

## Files changed

- `errors.go` — `filterErr`, `asFilterErr`
- `filters/metadata.go` — `deserializationErr`, `metadataEventFilterErr`, `asDeserializationErr`, `makeMetadataEventFilterErr`
- `filters/metadata_test.go` — `"constructed deserialization error"` want: false
- `rpatterns/batch_test.go` — `TestReset` uses `errEvents` instead of local `recvEndErr`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a named error for invalid batch configuration to make misconfiguration detection clearer.

* **Bug Fixes**
  * Improved error diagnostics by annotating sentinel errors for more reliable identification without altering control flow or semantics.

* **Tests**
  * Updated tests to align with annotated error behaviour and the new batch-config error; consolidated test messages and shared fixtures for more stable assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->