### PR TITLE
rblob: add WithKeyFilter functional option

### DIFF
--- a/rblob/blob.go
+++ b/rblob/blob.go
@@ -43,6 +43,20 @@ func WithDecoder(fn func(io.Reader) (Decoder, error)) Option {
 	}
 }
 
+// WithKeyFilter returns an option to configure a custom filter for selecting
+// the next blob key during listing. The function receives the previous key and
+// the current ListObject candidate; return true to select it as the next key.
+// Defaults to o.Key > prev (lexicographic ordering).
+func WithKeyFilter(fn func(prev string, o *blob.ListObject) bool) Option {
+	return func(b *Bucket) {
+		if fn == nil {
+			b.keyFilter = defaultKeyFilter
+			return
+		}
+		b.keyFilter = fn
+	}
+}
+
 // Option is a functional option that configures a bucket.
 type Option func(*Bucket)
 
@@ -65,6 +79,11 @@ func OpenBucket(ctx context.Context, label, urlstr string,
 	return NewBucket(label, bucket, opts...), nil
 }
 
+// defaultKeyFilter selects the next key using lexicographic ordering.
+func defaultKeyFilter(prev string, o *blob.ListObject) bool {
+	return o.Key > prev
+}
+
 // NewBucket returns a bucket using the provided underlying bucket.
 func NewBucket(label string, bucket *blob.Bucket, opts ...Option) *Bucket {
 	b := &Bucket{
@@ -72,6 +91,7 @@ func NewBucket(label string, bucket *blob.Bucket, opts ...Option) *Bucket {
 		bucket:      bucket,
 		decoderFunc: JSONDecoder,
 		backoff:     time.Minute,
+		keyFilter:   defaultKeyFilter,
 	}
 
 	for _, opt := range opts {
@@ -88,6 +108,7 @@ type Bucket struct {
 	bucket      *blob.Bucket
 	decoderFunc func(io.Reader) (Decoder, error)
 	backoff     time.Duration
+	keyFilter   func(prev string, o *blob.ListObject) bool
 
 	cursor  cursor
 	decoder Decoder
@@ -124,6 +145,7 @@ func (b *Bucket) Stream(ctx context.Context, after string,
 		bucket:      b.bucket,
 		decoderFunc: b.decoderFunc,
 		backoff:     b.backoff,
+		keyFilter:   b.keyFilter,
 		cursor:      cursor,
 	}, nil
 }
@@ -139,6 +161,7 @@ type stream struct {
 	bucket      *blob.Bucket
 	decoderFunc func(io.Reader) (Decoder, error)
 	backoff     time.Duration
+	keyFilter   func(prev string, o *blob.ListObject) bool
 
 	next     []byte
 	cursor   cursor
@@ -273,7 +296,7 @@ func (s *stream) loadNextBlob() error {
 	var key string
 	for {
 		var err error
-		key, err = getNextKey(s.ctx, s.label, s.bucket, s.cursor.Key)
+		key, err = getNextKey(s.ctx, s.label, s.bucket, s.cursor.Key, s.keyFilter)
 		if errors.Is(err, io.EOF) {
 			// No key keys, wait.
 			select {
@@ -328,7 +351,7 @@ func (s *stream) loadNextBlob() error {
 	return nil
 }
 
-func getNextKey(ctx context.Context, label string, bucket *blob.Bucket, prev string) (string, error) {
+func getNextKey(ctx context.Context, label string, bucket *blob.Bucket, prev string, filter func(prev string, o *blob.ListObject) bool) (string, error) {
 	iter := bucket.List(&blob.ListOptions{
 		BeforeList: makeStartAfter(prev),
 	})
@@ -339,7 +362,7 @@ func getNextKey(ctx context.Context, label string, bucket *blob.Bucket, prev str
 			return "", errors.Wrap(err, "list iter")
 		}
 
-		if o.Key > prev {
+		if filter(prev, o) {
 			return o.Key, nil
 		}
 

--- a/rblob/blob_internal_test.go
+++ b/rblob/blob_internal_test.go
@@ -2,14 +2,18 @@ package rblob
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"os"
 	"path"
 	"sort"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/luno/jettison/jtest"
 	"github.com/stretchr/testify/require"
+	"gocloud.dev/blob"
 	_ "gocloud.dev/blob/fileblob"
 )
 
@@ -81,6 +85,104 @@ func TestCursor(t *testing.T) {
 	clone := append([]string(nil), order...)
 	sort.Strings(order)
 	require.Equal(t, clone, order)
+}
+
+func TestWithKeyFilter(t *testing.T) {
+	workDir, err := os.Getwd()
+	require.NoError(t, err)
+
+	tests := []struct {
+		name string
+		run  func(t *testing.T)
+	}{
+		// Option-level: verify nil guard and custom fn wiring against b.keyFilter directly.
+		{
+			name: "nil falls back to default: key greater than prev",
+			run: func(t *testing.T) {
+				b := &Bucket{}
+				WithKeyFilter(nil)(b)
+				require.NotNil(t, b.keyFilter)
+				require.True(t, b.keyFilter("a", &blob.ListObject{Key: "b"}))
+			},
+		},
+		{
+			name: "nil falls back to default: key not greater than prev",
+			run: func(t *testing.T) {
+				b := &Bucket{}
+				WithKeyFilter(nil)(b)
+				require.False(t, b.keyFilter("b", &blob.ListObject{Key: "a"}))
+			},
+		},
+		{
+			name: "custom fn overrides default",
+			run: func(t *testing.T) {
+				b := &Bucket{}
+				WithKeyFilter(func(_ string, _ *blob.ListObject) bool { return false })(b)
+				require.NotNil(t, b.keyFilter)
+				require.False(t, b.keyFilter("a", &blob.ListObject{Key: "b"})) // default would return true
+			},
+		},
+		// Integration: verify the filter is honoured end-to-end through the stream.
+		{
+			name: "key prefix excludes 2019 blobs",
+			run: func(t *testing.T) {
+				bucket, err := OpenBucket(context.Background(), "",
+					"file:///"+path.Join(workDir, "testdata"),
+					WithKeyFilter(func(prev string, o *blob.ListObject) bool {
+						return o.Key > prev && !strings.HasPrefix(o.Key, "2019")
+					}))
+				require.NoError(t, err)
+				t.Cleanup(func() { require.NoError(t, bucket.Close()) })
+
+				sc, err := bucket.Stream(context.Background(), "")
+				require.NoError(t, err)
+
+				for _, wantID := range []int64{4, 5, 6, 7} {
+					e, err := sc.Recv()
+					jtest.Require(t, nil, err)
+					var got struct {
+						ID int64 `json:"id"`
+					}
+					require.NoError(t, json.Unmarshal(e.MetaData, &got))
+					require.Equal(t, wantID, got.ID)
+				}
+			},
+		},
+		{
+			name: "mod time excludes old blobs",
+			run: func(t *testing.T) {
+				dir := t.TempDir()
+				oldFile := path.Join(dir, "file-a")
+				require.NoError(t, os.WriteFile(oldFile, []byte(`{"id":1,"field":"old"}`), 0o644))
+				backdated := time.Now().Add(-2 * time.Hour)
+				require.NoError(t, os.Chtimes(oldFile, backdated, backdated))
+				require.NoError(t, os.WriteFile(path.Join(dir, "file-b"), []byte(`{"id":2,"field":"new"}`), 0o644))
+
+				bucket, err := OpenBucket(context.Background(), "", "file:///"+dir,
+					WithKeyFilter(func(prev string, o *blob.ListObject) bool {
+						return o.Key > prev && o.ModTime.After(time.Now().Add(-1*time.Hour))
+					}),
+					WithBackoff(time.Millisecond))
+				require.NoError(t, err)
+				t.Cleanup(func() { require.NoError(t, bucket.Close()) })
+
+				sc, err := bucket.Stream(context.Background(), "")
+				require.NoError(t, err)
+
+				e, err := sc.Recv()
+				jtest.Require(t, nil, err)
+				var got struct {
+					ID int64 `json:"id"`
+				}
+				require.NoError(t, json.Unmarshal(e.MetaData, &got))
+				require.Equal(t, int64(2), got.ID)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) { tc.run(t) })
+	}
 }
 
 func Test_makeStartAfter(t *testing.T) {


### PR DESCRIPTION
Adds WithKeyFilter(fn func(prev string, o *blob.ListObject) bool) so callers can customise how the next blob key is selected.

Extracts the existing o.Key > prev check into defaultKeyFilter so there is no behaviour change for callers that do not set the option.

## For External Submissions:

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/luno/.github/blob/main/CONTRIBUTING.md) file?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [ ] If it's a non-trivial change, I've linked a new or existing [issue](../issues) to this PR
- [ ] I have performed a self-review of my code
- [ ] Does your submission pass existing tests?
- [ ] Have you written new tests for your new changes, if applicable?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a customisable key filter option for blob listing operations. This enhancement provides flexible blob selection logic during streaming, allowing filters based on key patterns, metadata attributes, and modification timestamps. Default lexicographic ordering remains in place when no custom filter is configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->