### PR TITLE
PTR-3591 Added modTimeCursor along with encode/decode functions

### DIFF
--- a/rblob/modTimeBlob.go
+++ b/rblob/modTimeBlob.go
@@ -1,0 +1,65 @@
+package rblob
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/luno/jettison/errors"
+)
+
+// modtimeCursor identifies the last-processed S3 object by its key and
+// last-modified time. ModTime is used for ordering; Key breaks ties and
+// provides identity for the resume skip.
+type modtimeCursor struct {
+	Key     string
+	ModTime time.Time
+}
+
+// String returns the string representation of the modtimeCursor.
+//
+// If the cursor key is empty, an empty string is returned.
+// Otherwise, the result is formatted as:
+//
+//	<key>|<modtime_unix_nano>
+//
+// where modtime_unix_nano is the modification time in Unix nanoseconds.
+func (c modtimeCursor) String() string {
+	if c.Key == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s|%d", c.Key, c.ModTime.UnixNano())
+}
+
+// parseModTimeCursor parses a modtime cursor string into a modtimeCursor value.
+//
+// The expected format is:
+//
+//	<key>|<modtime_unix_nano>
+//
+// where modtime_unix_nano is a Unix timestamp in nanoseconds.
+//
+// An empty string returns an empty modtimeCursor and no error.
+// An error is returned if the cursor format is invalid or the timestamp
+// cannot be parsed.
+func parseModTimeCursor(s string) (modtimeCursor, error) {
+	if s == "" {
+		return modtimeCursor{}, nil
+	}
+
+	key, rest, found := strings.Cut(s, "|")
+	if !found {
+		return modtimeCursor{}, errors.New("invalid modtime cursor: missing separator")
+	}
+
+	ns, err := strconv.ParseInt(rest, 10, 64)
+	if err != nil {
+		return modtimeCursor{}, errors.New("invalid modtime cursor: bad unix-nano")
+	}
+
+	return modtimeCursor{
+		Key:     key,
+		ModTime: time.Unix(0, ns).UTC(),
+	}, nil
+}

--- a/rblob/modTimeBlob.go
+++ b/rblob/modTimeBlob.go
@@ -11,12 +11,18 @@ import (
 
 // --------------------------------------------------------------------------------------------
 // This differs from the regular blob functionality, in that it is designed to resume
-// its cursor based on the comparisions on last modified rather than on lexicographic
+// its cursor based on the comparisons on last modified rather than on lexicographic
 // ordering. Since this is not supported in the AWS ListObjectsV2 client (https://docs.aws.amazon.com/cli/latest/reference/s3api/list-objects-v2.html)
 // (on the day this is documented 2026-05-26). This should only be used for small to
 // medium size S3 buckets. Reason being that the cursor will need to iterate through all
 // the last modified list objects to determine its resume position.
 // --------------------------------------------------------------------------------------------
+
+var (
+	errModTimeCursorMissingSeparator = errors.New("invalid modtime cursor: missing separator")
+	errModTimeCursorEmptyKey         = errors.New("invalid modtime cursor: empty key")
+	errModTimeCursorBadUnixNano      = errors.New("invalid modtime cursor: bad unix-nano")
+)
 
 // modtimeCursor identifies the last-processed S3 object by its key and
 // last-modified time. ModTime is used for ordering; Key breaks ties and
@@ -59,17 +65,17 @@ func parseModTimeCursor(s string) (modtimeCursor, error) {
 
 	idx := strings.LastIndex(s, "|")
 	if idx < 0 {
-		return modtimeCursor{}, errors.New("invalid modtime cursor: missing separator")
+		return modtimeCursor{}, errors.Wrap(errModTimeCursorMissingSeparator, "")
 	}
 	key := s[:idx]
 	rest := s[idx+1:]
 	if key == "" {
-		return modtimeCursor{}, errors.New("invalid modtime cursor: empty key")
+		return modtimeCursor{}, errors.Wrap(errModTimeCursorEmptyKey, "")
 	}
 
 	ns, err := strconv.ParseInt(rest, 10, 64)
 	if err != nil {
-		return modtimeCursor{}, errors.New("invalid modtime cursor: bad unix-nano")
+		return modtimeCursor{}, errors.Wrap(errModTimeCursorBadUnixNano, "")
 	}
 
 	return modtimeCursor{

--- a/rblob/modTimeBlob.go
+++ b/rblob/modTimeBlob.go
@@ -57,9 +57,14 @@ func parseModTimeCursor(s string) (modtimeCursor, error) {
 		return modtimeCursor{}, nil
 	}
 
-	key, rest, found := strings.Cut(s, "|")
-	if !found {
+	idx := strings.LastIndex(s, "|")
+	if idx < 0 {
 		return modtimeCursor{}, errors.New("invalid modtime cursor: missing separator")
+	}
+	key := s[:idx]
+	rest := s[idx+1:]
+	if key == "" {
+		return modtimeCursor{}, errors.New("invalid modtime cursor: empty key")
 	}
 
 	ns, err := strconv.ParseInt(rest, 10, 64)

--- a/rblob/modTimeBlob.go
+++ b/rblob/modTimeBlob.go
@@ -9,6 +9,15 @@ import (
 	"github.com/luno/jettison/errors"
 )
 
+// --------------------------------------------------------------------------------------------
+// This differs from the regular blob functionality, in that it is designed to resume
+// its cursor based on the comparisions on last modified rather than on lexicographic
+// ordering. Since this is not supported in the AWS ListObjectsV2 client (https://docs.aws.amazon.com/cli/latest/reference/s3api/list-objects-v2.html)
+// (on the day this is documented 2026-05-26). This should only be used for small to
+// medium size S3 buckets. Reason being that the cursor will need to iterate through all
+// the last modified list objects to determine its resume position.
+// --------------------------------------------------------------------------------------------
+
 // modtimeCursor identifies the last-processed S3 object by its key and
 // last-modified time. ModTime is used for ordering; Key breaks ties and
 // provides identity for the resume skip.

--- a/rblob/modTimeBlob_internal_test.go
+++ b/rblob/modTimeBlob_internal_test.go
@@ -49,36 +49,50 @@ func TestModtimeCursor_String(t *testing.T) {
 }
 
 func TestParseModTimeCursor(t *testing.T) {
-	t.Run("empty string returns zero cursor", func(t *testing.T) {
-		c, err := parseModTimeCursor("")
-		jtest.RequireNil(t, err)
-		require.Equal(t, modtimeCursor{}, c)
-	})
+	tests := []struct {
+		name    string
+		input   string
+		want    modtimeCursor
+		wantErr string
+	}{
+		{
+			name:  "empty string returns zero cursor",
+			input: "",
+			want:  modtimeCursor{},
+		},
+		{
+			name:    "when no key is provided",
+			input:   "|borderlineSomethingSomething",
+			wantErr: "empty key",
+		},
+		{
+			name:    "missing separator returns error",
+			input:   "nokeynoseparator",
+			wantErr: "missing separator",
+		},
+		{
+			name:    "non-integer unix-nano returns error",
+			input:   "somekey|notanumber",
+			wantErr: "bad unix-nano",
+		},
+		{
+			name:  "valid cursor parses correctly",
+			input: "path/to/obj|1000000000",
+			want:  modtimeCursor{Key: "path/to/obj", ModTime: time.Unix(0, 1_000_000_000).UTC()},
+		},
+	}
 
-	t.Run("when no key is provided", func(t *testing.T) {
-		_, err := parseModTimeCursor("|borderlineSomethingSomething")
-		require.Error(t, err)
-		require.ErrorContains(t, err, "empty key")
-	})
-
-	t.Run("missing separator returns error", func(t *testing.T) {
-		_, err := parseModTimeCursor("nokeynoseparator")
-		require.Error(t, err)
-		require.ErrorContains(t, err, "missing separator")
-	})
-
-	t.Run("non-integer unix-nano returns error", func(t *testing.T) {
-		_, err := parseModTimeCursor("somekey|notanumber")
-		require.Error(t, err)
-		require.ErrorContains(t, err, "bad unix-nano")
-	})
-
-	t.Run("valid cursor parses correctly", func(t *testing.T) {
-		c, err := parseModTimeCursor("path/to/obj|1000000000")
-		jtest.RequireNil(t, err)
-		require.Equal(t, "path/to/obj", c.Key)
-		require.Equal(t, time.Unix(0, 1_000_000_000).UTC(), c.ModTime)
-	})
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c, err := parseModTimeCursor(tc.input)
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+				return
+			}
+			jtest.RequireNil(t, err)
+			require.Equal(t, tc.want, c)
+		})
+	}
 }
 
 func TestModtimeCursor_RoundTrip(t *testing.T) {

--- a/rblob/modTimeBlob_internal_test.go
+++ b/rblob/modTimeBlob_internal_test.go
@@ -1,0 +1,90 @@
+package rblob
+
+import (
+	"testing"
+	"time"
+
+	"github.com/luno/jettison/jtest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestModtimeCursor_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		cursor   modtimeCursor
+		expected string
+	}{
+		{
+			name:     "empty key returns empty string",
+			cursor:   modtimeCursor{},
+			expected: "",
+		},
+		{
+			name:     "empty key with non-zero modtime still returns empty string",
+			cursor:   modtimeCursor{Key: "", ModTime: time.Unix(0, 1234567890)},
+			expected: "",
+		},
+		{
+			name:     "key with zero modtime",
+			cursor:   modtimeCursor{Key: "some/key", ModTime: time.Time{}},
+			expected: "some/key|-6795364578871345152",
+		},
+		{
+			name:     "key with positive unix-nano",
+			cursor:   modtimeCursor{Key: "a/b/c", ModTime: time.Unix(0, 1_000_000_000)},
+			expected: "a/b/c|1000000000",
+		},
+		{
+			name:     "key containing pipe character",
+			cursor:   modtimeCursor{Key: "file|with|pipes", ModTime: time.Unix(0, 42)},
+			expected: "file|with|pipes|42",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, tc.cursor.String())
+		})
+	}
+}
+
+func TestParseModTimeCursor(t *testing.T) {
+	t.Run("empty string returns zero cursor", func(t *testing.T) {
+		c, err := parseModTimeCursor("")
+		jtest.RequireNil(t, err)
+		require.Equal(t, modtimeCursor{}, c)
+	})
+
+	t.Run("missing separator returns error", func(t *testing.T) {
+		_, err := parseModTimeCursor("nokeynoseparator")
+		require.Error(t, err)
+		require.ErrorContains(t, err, "missing separator")
+	})
+
+	t.Run("non-integer unix-nano returns error", func(t *testing.T) {
+		_, err := parseModTimeCursor("somekey|notanumber")
+		require.Error(t, err)
+		require.ErrorContains(t, err, "bad unix-nano")
+	})
+
+	t.Run("valid cursor parses correctly", func(t *testing.T) {
+		c, err := parseModTimeCursor("path/to/obj|1000000000")
+		jtest.RequireNil(t, err)
+		require.Equal(t, "path/to/obj", c.Key)
+		require.Equal(t, time.Unix(0, 1_000_000_000).UTC(), c.ModTime)
+	})
+}
+
+func TestModtimeCursor_RoundTrip(t *testing.T) {
+	original := modtimeCursor{
+		Key:     "2024/01/15/event.json",
+		ModTime: time.Unix(1705276800, 123456789).UTC(),
+	}
+
+	s := original.String()
+	require.NotEmpty(t, s)
+
+	parsed, err := parseModTimeCursor(s)
+	jtest.RequireNil(t, err)
+	require.Equal(t, original, parsed)
+}

--- a/rblob/modTimeBlob_internal_test.go
+++ b/rblob/modTimeBlob_internal_test.go
@@ -55,6 +55,12 @@ func TestParseModTimeCursor(t *testing.T) {
 		require.Equal(t, modtimeCursor{}, c)
 	})
 
+	t.Run("when no key is provided", func(t *testing.T) {
+		_, err := parseModTimeCursor("|borderlineSomethingSomething")
+		require.Error(t, err)
+		require.ErrorContains(t, err, "empty key")
+	})
+
 	t.Run("missing separator returns error", func(t *testing.T) {
 		_, err := parseModTimeCursor("nokeynoseparator")
 		require.Error(t, err)

--- a/rblob/modTimeBlob_internal_test.go
+++ b/rblob/modTimeBlob_internal_test.go
@@ -53,7 +53,7 @@ func TestParseModTimeCursor(t *testing.T) {
 		name    string
 		input   string
 		want    modtimeCursor
-		wantErr string
+		wantErr error
 	}{
 		{
 			name:  "empty string returns zero cursor",
@@ -63,17 +63,17 @@ func TestParseModTimeCursor(t *testing.T) {
 		{
 			name:    "when no key is provided",
 			input:   "|borderlineSomethingSomething",
-			wantErr: "empty key",
+			wantErr: errModTimeCursorEmptyKey,
 		},
 		{
 			name:    "missing separator returns error",
 			input:   "nokeynoseparator",
-			wantErr: "missing separator",
+			wantErr: errModTimeCursorMissingSeparator,
 		},
 		{
 			name:    "non-integer unix-nano returns error",
 			input:   "somekey|notanumber",
-			wantErr: "bad unix-nano",
+			wantErr: errModTimeCursorBadUnixNano,
 		},
 		{
 			name:  "valid cursor parses correctly",
@@ -85,11 +85,11 @@ func TestParseModTimeCursor(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			c, err := parseModTimeCursor(tc.input)
-			if tc.wantErr != "" {
-				require.ErrorContains(t, err, tc.wantErr)
+			if tc.wantErr != nil {
+				jtest.Require(t, tc.wantErr, err)
 				return
 			}
-			jtest.RequireNil(t, err)
+			jtest.Require(t, nil, err)
 			require.Equal(t, tc.want, c)
 		})
 	}


### PR DESCRIPTION
## For External Submissions:

Addresses Issue #98 

- [x] Have you followed the guidelines in our [Contributing](https://github.com/luno/.github/blob/main/CONTRIBUTING.md) file?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [x] If it's a non-trivial change, I've linked a new or existing [issue](../issues) to this PR
- [x] I have performed a self-review of my code
- [x] Does your submission pass existing tests?
- [x] Have you written new tests for your new changes, if applicable?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added progress tracking for S3 listing operations using timestamp-based cursors with object-key tie-breakers for precise resumption.

* **Tests**
  * Added tests covering cursor serialisation/parsing, empty-input handling, error cases and round-trip consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->