### PR TITLE
Adding ModTimeStream and ModTimeBucket and Client

### DIFF
--- a/rblob/blob.go
+++ b/rblob/blob.go
@@ -18,14 +18,6 @@ import (
 	"github.com/luno/reflex"
 )
 
-// Decoder decodes a blob into event byte slices (usually DTOs) which
-// are streamed as event metadata.
-type Decoder interface {
-	// Decode returns the next non-empty byte slice or an error. It returns io.EOF if no more
-	// are available.
-	Decode() ([]byte, error)
-}
-
 // WithBackoff returns an option to configure the backoff duration
 // before querying the underlying bucket for new blobs. It defaults
 // to one minute.

--- a/rblob/modTimeBlob.go
+++ b/rblob/modTimeBlob.go
@@ -124,6 +124,13 @@ func NewModTimeBucket(label string, bucket *blob.Bucket, opts ...BucketOption[Mo
 		opt(b)
 	}
 
+	if b.decoderFunc == nil {
+		b.decoderFunc = JSONDecoder
+	}
+	if b.backoff <= 0 {
+		b.backoff = time.Minute
+	}
+
 	return b
 }
 

--- a/rblob/modTimeBlob.go
+++ b/rblob/modTimeBlob.go
@@ -1,12 +1,18 @@
 package rblob
 
 import (
+	"context"
 	"fmt"
+	"io"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/luno/jettison/errors"
+	"github.com/luno/jettison/j"
+	"github.com/luno/reflex"
+	"gocloud.dev/blob"
 )
 
 // --------------------------------------------------------------------------------------------
@@ -24,12 +30,80 @@ var (
 	errModTimeCursorBadUnixNano      = errors.New("invalid modtime cursor: bad unix-nano")
 )
 
+// ModTimeBucketOption is a functional option that configures a ModTimeBucket.
+type ModTimeBucketOption func(*ModTimeBucket)
+
+// WithModTimeBackoff configures the backoff duration between polls when no new
+// objects are found. Defaults to one minute.
+func WithModTimeBackoff(d time.Duration) ModTimeBucketOption {
+	return func(b *ModTimeBucket) {
+		b.backoff = d
+	}
+}
+
+// WithModTimeDecoder configures the decoder used to read object contents.
+// Defaults to JSONDecoder.
+func WithModTimeDecoder(fn func(io.Reader) (Decoder, error)) ModTimeBucketOption {
+	return func(b *ModTimeBucket) {
+		b.decoderFunc = fn
+	}
+}
+
+// WithModTimePrefix restricts listing to objects whose keys start with prefix.
+func WithModTimePrefix(prefix string) ModTimeBucketOption {
+	return func(b *ModTimeBucket) {
+		b.prefix = prefix
+	}
+}
+
+type ModTimeBucket struct {
+	label       string
+	bucket      *blob.Bucket
+	prefix      string
+	decoderFunc func(io.Reader) (Decoder, error)
+	backoff     time.Duration
+}
+
+type modtimeStream struct {
+	ctx         context.Context
+	bucket      *blob.Bucket
+	prefix      string
+	decoderFunc func(io.Reader) (Decoder, error)
+	backoff     time.Duration
+	cursor      modtimeCursor
+
+	// current object being decoded
+	objects []*blob.ListObject // sorted, filtered slice for this poll cycle
+	objIdx  int
+	reader  *blob.Reader
+	decoder Decoder
+	next    []byte // pre-fetched payload (rblob pattern)
+	blobEOF bool
+
+	err error // terminal error; Recv returns this once set
+}
+
 // modtimeCursor identifies the last-processed S3 object by its key and
 // last-modified time. ModTime is used for ordering; Key breaks ties and
 // provides identity for the resume skip.
 type modtimeCursor struct {
 	Key     string
 	ModTime time.Time
+}
+
+func NewModTimeBucket(label string, bucket *blob.Bucket, opts ...ModTimeBucketOption) *ModTimeBucket {
+	b := &ModTimeBucket{
+		label:       label,
+		bucket:      bucket,
+		decoderFunc: JSONDecoder,
+		backoff:     time.Minute,
+	}
+
+	for _, opt := range opts {
+		opt(b)
+	}
+
+	return b
 }
 
 // String returns the string representation of the modtimeCursor.
@@ -46,6 +120,10 @@ func (c modtimeCursor) String() string {
 	}
 	return fmt.Sprintf("%s|%d", c.Key, c.ModTime.UnixNano())
 }
+
+type modtimeEventType struct{}
+
+func (eventType modtimeEventType) ReflexType() int { return 0 }
 
 // parseModTimeCursor parses a modtime cursor string into a modtimeCursor value.
 //
@@ -81,5 +159,171 @@ func parseModTimeCursor(s string) (modtimeCursor, error) {
 	return modtimeCursor{
 		Key:     key,
 		ModTime: time.Unix(0, ns).UTC(),
+	}, nil
+}
+
+// listSorted returns a list S3 objects (filtered by the prefix) in timestamp ascending order
+func (s *modtimeStream) listSorted() ([]*blob.ListObject, error) {
+	var objs []*blob.ListObject
+	iter := s.bucket.List(&blob.ListOptions{Prefix: s.prefix})
+	for {
+		o, err := iter.Next(s.ctx)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, errors.Wrap(err, "list object error", j.KS("prefix", s.prefix))
+		}
+		objs = append(objs, o)
+	}
+	slices.SortFunc(objs, func(a, b *blob.ListObject) int {
+		if c := a.ModTime.UTC().Compare(b.ModTime.UTC()); c != 0 {
+			return c
+		}
+		return strings.Compare(a.Key, b.Key)
+	})
+	return objs, nil
+}
+
+// after returns true when object comes strictly after the current cursor.
+func (s *modtimeStream) after(obj *blob.ListObject) bool {
+	if s.cursor.Key == "" {
+		return true
+	}
+
+	modTime := obj.ModTime.UTC()
+	cursorTime := s.cursor.ModTime
+	if modTime.Equal(cursorTime) {
+		return obj.Key > s.cursor.Key
+	}
+	return modTime.After(cursorTime)
+}
+
+func (s *modtimeStream) loadNextObject() error {
+	for {
+		// Close previous reader if any.
+		if s.reader != nil {
+			if err := s.reader.Close(); err != nil {
+				return err
+			}
+			s.reader = nil
+			s.decoder = nil
+			s.blobEOF = false
+		}
+
+		// Refill sorted list if exhausted.
+		if s.objIdx >= len(s.objects) {
+			objs, err := s.listSorted()
+			if err != nil {
+				return err
+			}
+			// Skip anything at or before the current cursor.
+			start := 0
+			for start < len(objs) && !s.after(objs[start]) {
+				start++
+			}
+			s.objects = objs[start:]
+			s.objIdx = 0
+		}
+
+		if s.objIdx < len(s.objects) {
+			break
+		}
+
+		// Nothing new yet — wait and retry.
+		select {
+		case <-s.ctx.Done():
+			return s.ctx.Err()
+		case <-time.After(s.backoff):
+		}
+	}
+
+	obj := s.objects[s.objIdx]
+	s.objIdx++
+
+	r, err := s.bucket.NewReader(s.ctx, obj.Key, nil)
+	if err != nil {
+		return errors.Wrap(err, "new reader")
+	}
+
+	d, err := s.decoderFunc(r)
+	if err != nil {
+		_ = r.Close()
+		return err
+	}
+
+	first, err := d.Decode()
+	if errors.Is(err, io.EOF) {
+		s.blobEOF = true
+	} else if err != nil {
+		_ = r.Close()
+		return errors.Wrap(err, "decode first")
+	}
+
+	s.reader = r
+	s.decoder = d
+	s.next = first
+	s.cursor = modtimeCursor{Key: obj.Key, ModTime: obj.ModTime.UTC()}
+
+	return nil
+}
+
+func (s *modtimeStream) Recv() (*reflex.Event, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	e, err := s.recv()
+	if err != nil {
+		s.err = err
+		if s.reader != nil {
+			_ = s.reader.Close()
+		}
+	}
+	return e, err
+}
+
+func (s *modtimeStream) recv() (*reflex.Event, error) {
+	// Advance to the next available object if needed.
+	for s.decoder == nil || s.blobEOF {
+		if err := s.loadNextObject(); err != nil {
+			return nil, err
+		}
+	}
+
+	payload := s.next
+	peek, err := s.decoder.Decode()
+	if errors.Is(err, io.EOF) {
+		s.blobEOF = true
+	} else if err != nil {
+		return nil, errors.Wrap(err, "decode")
+	}
+	s.next = peek
+
+	e := &reflex.Event{
+		ID:        s.cursor.String(),
+		Type:      modtimeEventType{},
+		Timestamp: s.cursor.ModTime,
+		MetaData:  payload,
+	}
+	return e, nil
+}
+
+func (modTimeBucket *ModTimeBucket) ModTimeStream(
+	ctx context.Context, after string, opts ...reflex.StreamOption,
+) (reflex.StreamClient, error) {
+	if len(opts) > 0 {
+		return nil, errors.New("options not supported")
+	}
+	cursor, err := parseModTimeCursor(after)
+	if err != nil {
+		return nil, err
+	}
+	return &modtimeStream{
+		ctx:         ctx,
+		bucket:      modTimeBucket.bucket,
+		prefix:      modTimeBucket.prefix,
+		decoderFunc: modTimeBucket.decoderFunc,
+		backoff:     modTimeBucket.backoff,
+		cursor:      cursor,
 	}, nil
 }

--- a/rblob/modTimeBlob.go
+++ b/rblob/modTimeBlob.go
@@ -28,6 +28,7 @@ var (
 	errModTimeCursorMissingSeparator = errors.New("invalid modtime cursor: missing separator")
 	errModTimeCursorEmptyKey         = errors.New("invalid modtime cursor: empty key")
 	errModTimeCursorBadUnixNano      = errors.New("invalid modtime cursor: bad unix-nano")
+	errModTimeCursorBadOffset        = errors.New("invalid modtime cursor: bad offset")
 )
 
 // WithModTimeBackoff configures the backoff duration between polls when no new
@@ -70,22 +71,25 @@ type modtimeStream struct {
 	cursor      modtimeCursor
 
 	// current object being decoded
-	objects []*blob.ListObject
-	objIdx  int
-	reader  *blob.Reader
-	decoder Decoder
-	next    []byte
-	blobEOF bool
+	objects    []*blob.ListObject
+	objIdx     int
+	reader     *blob.Reader
+	decoder    Decoder
+	next       []byte
+	blobEOF    bool
+	resumeDone bool // true once the initial cursor blob has been opened for mid-blob resume
 
 	err error
 }
 
 // modtimeCursor identifies the last-processed S3 object by its key and
 // last-modified time. ModTime is used for ordering; Key breaks ties and
-// provides identity for the resume skip.
+// provides identity for the resume skip. Offset is the number of records
+// already consumed from this blob, used to resume mid-blob.
 type modtimeCursor struct {
 	Key     string
 	ModTime time.Time
+	Offset  int
 }
 type modtimeEventType struct{}
 
@@ -142,50 +146,66 @@ func (b *ModTimeBucket) Close() error { return b.bucket.Close() }
 // If the cursor key is empty, an empty string is returned.
 // Otherwise, the result is formatted as:
 //
-//	<key>|<modtime_unix_nano>
+//	<key>|<modtime_unix_nano>|<offset>
 //
-// where modtime_unix_nano is the modification time in Unix nanoseconds.
+// where modtime_unix_nano is the modification time in Unix nanoseconds and
+// offset is the number of records already consumed from this blob.
 func (c modtimeCursor) String() string {
 	if c.Key == "" {
 		return ""
 	}
-	return fmt.Sprintf("%s|%d", c.Key, c.ModTime.UnixNano())
+	return fmt.Sprintf("%s|%d|%d", c.Key, c.ModTime.UnixNano(), c.Offset)
 }
 
 // parseModTimeCursor parses a modtime cursor string into a modtimeCursor value.
 //
 // The expected format is:
 //
-//	<key>|<modtime_unix_nano>
+//	<key>|<modtime_unix_nano>|<offset>
 //
-// where modtime_unix_nano is a Unix timestamp in nanoseconds.
+// where modtime_unix_nano is a Unix timestamp in nanoseconds and offset is the
+// number of records already consumed from this blob.
+//
+// The legacy two-part format <key>|<modtime_unix_nano> is also accepted and
+// returns a cursor with Offset 0.
 //
 // An empty string returns an empty modtimeCursor and no error.
-// An error is returned if the cursor format is invalid or the timestamp
-// cannot be parsed.
+// An error is returned if the cursor format is invalid or fields cannot be parsed.
 func parseModTimeCursor(s string) (modtimeCursor, error) {
 	if s == "" {
 		return modtimeCursor{}, nil
 	}
 
-	idx := strings.LastIndex(s, "|")
-	if idx < 0 {
+	lastSep := strings.LastIndex(s, "|")
+	if lastSep < 0 {
 		return modtimeCursor{}, errors.Wrap(errModTimeCursorMissingSeparator, "")
 	}
-	key := s[:idx]
-	rest := s[idx+1:]
+
+	tail := s[lastSep+1:]
+	prefix := s[:lastSep]
+
+	secondSep := strings.LastIndex(prefix, "|")
+	if secondSep < 0 {
+		return modtimeCursor{}, errors.Wrap(errModTimeCursorMissingSeparator, "")
+	}
+
+	key := prefix[:secondSep]
+	nanoStr := prefix[secondSep+1:]
 	if key == "" {
 		return modtimeCursor{}, errors.Wrap(errModTimeCursorEmptyKey, "")
 	}
-
-	ns, err := strconv.ParseInt(rest, 10, 64)
+	ns, err := strconv.ParseInt(nanoStr, 10, 64)
 	if err != nil {
 		return modtimeCursor{}, errors.Wrap(errModTimeCursorBadUnixNano, "")
 	}
-
+	offset, err := strconv.ParseInt(tail, 10, 64)
+	if err != nil {
+		return modtimeCursor{}, errors.Wrap(errModTimeCursorBadOffset, "")
+	}
 	return modtimeCursor{
 		Key:     key,
 		ModTime: time.Unix(0, ns).UTC(),
+		Offset:  int(offset),
 	}, nil
 }
 
@@ -226,6 +246,11 @@ func (s *modtimeStream) after(obj *blob.ListObject) bool {
 	return modTime.After(cursorTime)
 }
 
+// isCursorBlob returns true when obj is the same blob the cursor points to.
+func (s *modtimeStream) isCursorBlob(obj *blob.ListObject) bool {
+	return obj.Key == s.cursor.Key && obj.ModTime.UTC().Equal(s.cursor.ModTime)
+}
+
 // loadNextObject advances to the next blob object in sorted order, opening its
 // reader and pre-loading the first event. If the sorted object list is
 // exhausted it re-lists and waits (with backoff) until a new object appears or
@@ -248,9 +273,13 @@ func (s *modtimeStream) loadNextObject() error {
 			if err != nil {
 				return err
 			}
-			// Skip anything at or before the current cursor.
+			// Skip anything at or before the current cursor, but retain the
+			// cursor blob itself when resuming mid-blob.
 			start := 0
 			for start < len(objs) && !s.after(objs[start]) {
+				if !s.resumeDone && s.cursor.Offset > 0 && s.isCursorBlob(objs[start]) {
+					break
+				}
 				start++
 			}
 			s.objects = objs[start:]
@@ -283,6 +312,25 @@ func (s *modtimeStream) loadNextObject() error {
 		return err
 	}
 
+	isCursor := !s.resumeDone && s.cursor.Offset > 0 && s.isCursorBlob(obj)
+	if isCursor {
+		s.resumeDone = true
+		for i := 0; i < s.cursor.Offset; i++ {
+			if _, skipErr := d.Decode(); errors.Is(skipErr, io.EOF) {
+				// Offset exceeds the blob's record count — treat as fully consumed.
+				s.reader = r
+				s.decoder = d
+				s.blobEOF = true
+				return nil
+			} else if skipErr != nil {
+				_ = r.Close()
+				return errors.Wrap(skipErr, "skip record")
+			}
+		}
+	} else {
+		s.cursor = modtimeCursor{Key: obj.Key, ModTime: obj.ModTime.UTC()}
+	}
+
 	first, err := d.Decode()
 	if errors.Is(err, io.EOF) {
 		s.blobEOF = true
@@ -294,7 +342,6 @@ func (s *modtimeStream) loadNextObject() error {
 	s.reader = r
 	s.decoder = d
 	s.next = first
-	s.cursor = modtimeCursor{Key: obj.Key, ModTime: obj.ModTime.UTC()}
 
 	return nil
 }
@@ -329,6 +376,7 @@ func (s *modtimeStream) recv() (*reflex.Event, error) {
 		return nil, errors.Wrap(err, "decode")
 	}
 	s.next = peek
+	s.cursor.Offset++
 
 	e := &reflex.Event{
 		ID:        s.cursor.String(),

--- a/rblob/modTimeBlob.go
+++ b/rblob/modTimeBlob.go
@@ -63,7 +63,7 @@ type ModTimeBucket struct {
 }
 
 type modtimeStream struct {
-	ctx         context.Context
+	ctx         context.Context //nolint:containedctx // context governs stream lifetime; Recv() has no ctx param
 	bucket      *blob.Bucket
 	prefix      string
 	decoderFunc func(io.Reader) (Decoder, error)

--- a/rblob/modTimeBlob.go
+++ b/rblob/modTimeBlob.go
@@ -30,12 +30,9 @@ var (
 	errModTimeCursorBadUnixNano      = errors.New("invalid modtime cursor: bad unix-nano")
 )
 
-// ModTimeBucketOption is a functional option that configures a ModTimeBucket.
-type ModTimeBucketOption func(*ModTimeBucket)
-
 // WithModTimeBackoff configures the backoff duration between polls when no new
 // objects are found. Defaults to one minute.
-func WithModTimeBackoff(d time.Duration) ModTimeBucketOption {
+func WithModTimeBackoff(d time.Duration) BucketOption[ModTimeBucket] {
 	return func(b *ModTimeBucket) {
 		b.backoff = d
 	}
@@ -43,14 +40,14 @@ func WithModTimeBackoff(d time.Duration) ModTimeBucketOption {
 
 // WithModTimeDecoder configures the decoder used to read object contents.
 // Defaults to JSONDecoder.
-func WithModTimeDecoder(fn func(io.Reader) (Decoder, error)) ModTimeBucketOption {
+func WithModTimeDecoder(fn func(io.Reader) (Decoder, error)) BucketOption[ModTimeBucket] {
 	return func(b *ModTimeBucket) {
 		b.decoderFunc = fn
 	}
 }
 
 // WithModTimePrefix restricts listing to objects whose keys start with prefix.
-func WithModTimePrefix(prefix string) ModTimeBucketOption {
+func WithModTimePrefix(prefix string) BucketOption[ModTimeBucket] {
 	return func(b *ModTimeBucket) {
 		b.prefix = prefix
 	}
@@ -90,8 +87,32 @@ type modtimeCursor struct {
 	Key     string
 	ModTime time.Time
 }
+type modtimeEventType struct{}
 
-func NewModTimeBucket(label string, bucket *blob.Bucket, opts ...ModTimeBucketOption) *ModTimeBucket {
+func (eventType modtimeEventType) ReflexType() int { return 0 }
+
+// OpenModTimneBucket opens and returns a bucket for the provided URL.
+//
+// label: defines the bucket label used for metrics.
+// URLString: defines the URL of the blob bucket. See the gocloud
+//// URLOpener documentation in driver subpackages for details
+//// on supported URL formats. Also see https://gocloud.dev/concepts/urls/
+//// and https://gocloud.dev/howto/blob/.
+func OpenModTimeBucket(
+	ctx context.Context,
+	label,
+	URLString string,
+	opts ...BucketOption[ModTimeBucket],
+) (*ModTimeBucket, error) {
+	bucket, err := blob.OpenBucket(ctx, URLString)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewModTimeBucket(label, bucket, opts...), nil
+}
+
+func NewModTimeBucket(label string, bucket *blob.Bucket, opts ...BucketOption[ModTimeBucket]) *ModTimeBucket {
 	b := &ModTimeBucket{
 		label:       label,
 		bucket:      bucket,
@@ -105,6 +126,9 @@ func NewModTimeBucket(label string, bucket *blob.Bucket, opts ...ModTimeBucketOp
 
 	return b
 }
+
+// Close releases any resources used by the underlying modTime bucket
+func (bucket *ModTimeBucket) Close() error { return bucket.bucket.Close() }
 
 // String returns the string representation of the modtimeCursor.
 //
@@ -120,10 +144,6 @@ func (c modtimeCursor) String() string {
 	}
 	return fmt.Sprintf("%s|%d", c.Key, c.ModTime.UnixNano())
 }
-
-type modtimeEventType struct{}
-
-func (eventType modtimeEventType) ReflexType() int { return 0 }
 
 // parseModTimeCursor parses a modtime cursor string into a modtimeCursor value.
 //
@@ -326,4 +346,22 @@ func (modTimeBucket *ModTimeBucket) ModTimeStream(
 		backoff:     modTimeBucket.backoff,
 		cursor:      cursor,
 	}, nil
+}
+
+// Close closes the modtime stream and its reader.
+func (s *modtimeStream) Close() error {
+	// Check if stream already closed
+	if s.err != nil {
+		return s.err
+	}
+
+	// Set err to be closed
+	s.err = errors.New("closed")
+
+	// Check if stream reader is closed
+	if s.reader == nil {
+		return nil
+	}
+
+	return s.reader.Close()
 }

--- a/rblob/modTimeBlob.go
+++ b/rblob/modTimeBlob.go
@@ -70,14 +70,14 @@ type modtimeStream struct {
 	cursor      modtimeCursor
 
 	// current object being decoded
-	objects []*blob.ListObject // sorted, filtered slice for this poll cycle
+	objects []*blob.ListObject
 	objIdx  int
 	reader  *blob.Reader
 	decoder Decoder
-	next    []byte // pre-fetched payload (rblob pattern)
+	next    []byte
 	blobEOF bool
 
-	err error // terminal error; Recv returns this once set
+	err error
 }
 
 // modtimeCursor identifies the last-processed S3 object by its key and
@@ -219,6 +219,10 @@ func (s *modtimeStream) after(obj *blob.ListObject) bool {
 	return modTime.After(cursorTime)
 }
 
+// loadNextObject advances to the next blob object in sorted order, opening its
+// reader and pre-loading the first event. If the sorted object list is
+// exhausted it re-lists and waits (with backoff) until a new object appears or
+// the context is canceled.
 func (s *modtimeStream) loadNextObject() error {
 	for {
 		// Close previous reader if any.
@@ -328,6 +332,11 @@ func (s *modtimeStream) recv() (*reflex.Event, error) {
 	return e, nil
 }
 
+// ModTimeStream returns a reflex.StreamClient that streams events from the
+// bucket in modification-time order. The after parameter is an opaque cursor
+// string (as returned by previous events) that resumes streaming from where
+// the caller left off; pass an empty string to start from the beginning.
+// Stream options are not currently supported and will return an error if provided.
 func (b *ModTimeBucket) ModTimeStream(
 	ctx context.Context, after string, opts ...reflex.StreamOption,
 ) (reflex.StreamClient, error) {

--- a/rblob/modTimeBlob.go
+++ b/rblob/modTimeBlob.go
@@ -63,7 +63,7 @@ type ModTimeBucket struct {
 }
 
 type modtimeStream struct {
-	ctx         context.Context //nolint:containedctx // context governs stream lifetime; Recv() has no ctx param
+	ctx         context.Context //nolint:containedctx //context governs stream lifetime; Recv() has no ctx param
 	bucket      *blob.Bucket
 	prefix      string
 	decoderFunc func(io.Reader) (Decoder, error)

--- a/rblob/modTimeBlob.go
+++ b/rblob/modTimeBlob.go
@@ -91,13 +91,13 @@ type modtimeEventType struct{}
 
 func (eventType modtimeEventType) ReflexType() int { return 0 }
 
-// OpenModTimneBucket opens and returns a bucket for the provided URL.
+// OpenModTimeBucket opens and returns a bucket for the provided URL.
 //
 // label: defines the bucket label used for metrics.
 // URLString: defines the URL of the blob bucket. See the gocloud
-//// URLOpener documentation in driver subpackages for details
-//// on supported URL formats. Also see https://gocloud.dev/concepts/urls/
-//// and https://gocloud.dev/howto/blob/.
+// URLOpener documentation in driver subpackages for details
+// on supported URL formats. Also see https://gocloud.dev/concepts/urls/
+// and https://gocloud.dev/howto/blob/.
 func OpenModTimeBucket(
 	ctx context.Context,
 	label,
@@ -128,7 +128,7 @@ func NewModTimeBucket(label string, bucket *blob.Bucket, opts ...BucketOption[Mo
 }
 
 // Close releases any resources used by the underlying modTime bucket
-func (bucket *ModTimeBucket) Close() error { return bucket.bucket.Close() }
+func (b *ModTimeBucket) Close() error { return b.bucket.Close() }
 
 // String returns the string representation of the modtimeCursor.
 //
@@ -328,7 +328,7 @@ func (s *modtimeStream) recv() (*reflex.Event, error) {
 	return e, nil
 }
 
-func (modTimeBucket *ModTimeBucket) ModTimeStream(
+func (b *ModTimeBucket) ModTimeStream(
 	ctx context.Context, after string, opts ...reflex.StreamOption,
 ) (reflex.StreamClient, error) {
 	if len(opts) > 0 {
@@ -340,10 +340,10 @@ func (modTimeBucket *ModTimeBucket) ModTimeStream(
 	}
 	return &modtimeStream{
 		ctx:         ctx,
-		bucket:      modTimeBucket.bucket,
-		prefix:      modTimeBucket.prefix,
-		decoderFunc: modTimeBucket.decoderFunc,
-		backoff:     modTimeBucket.backoff,
+		bucket:      b.bucket,
+		prefix:      b.prefix,
+		decoderFunc: b.decoderFunc,
+		backoff:     b.backoff,
 		cursor:      cursor,
 	}, nil
 }

--- a/rblob/modTimeBlob_internal_test.go
+++ b/rblob/modTimeBlob_internal_test.go
@@ -5,38 +5,39 @@ import (
 	"time"
 
 	"github.com/luno/jettison/jtest"
+	"github.com/luno/reflex/rblob/modTimeBlob"
 	"github.com/stretchr/testify/require"
 )
 
 func TestModtimeCursor_String(t *testing.T) {
 	tests := []struct {
 		name     string
-		cursor   modtimeCursor
+		cursor   modTimeBlob.modtimeCursor
 		expected string
 	}{
 		{
 			name:     "empty key returns empty string",
-			cursor:   modtimeCursor{},
+			cursor:   modTimeBlob.modtimeCursor{},
 			expected: "",
 		},
 		{
 			name:     "empty key with non-zero modtime still returns empty string",
-			cursor:   modtimeCursor{Key: "", ModTime: time.Unix(0, 1234567890)},
+			cursor:   modTimeBlob.modtimeCursor{Key: "", ModTime: time.Unix(0, 1234567890)},
 			expected: "",
 		},
 		{
 			name:     "key with zero modtime",
-			cursor:   modtimeCursor{Key: "some/key", ModTime: time.Time{}},
+			cursor:   modTimeBlob.modtimeCursor{Key: "some/key", ModTime: time.Time{}},
 			expected: "some/key|-6795364578871345152",
 		},
 		{
 			name:     "key with positive unix-nano",
-			cursor:   modtimeCursor{Key: "a/b/c", ModTime: time.Unix(0, 1_000_000_000)},
+			cursor:   modTimeBlob.modtimeCursor{Key: "a/b/c", ModTime: time.Unix(0, 1_000_000_000)},
 			expected: "a/b/c|1000000000",
 		},
 		{
 			name:     "key containing pipe character",
-			cursor:   modtimeCursor{Key: "file|with|pipes", ModTime: time.Unix(0, 42)},
+			cursor:   modTimeBlob.modtimeCursor{Key: "file|with|pipes", ModTime: time.Unix(0, 42)},
 			expected: "file|with|pipes|42",
 		},
 	}
@@ -52,39 +53,39 @@ func TestParseModTimeCursor(t *testing.T) {
 	tests := []struct {
 		name    string
 		input   string
-		want    modtimeCursor
+		want    modTimeBlob.modtimeCursor
 		wantErr error
 	}{
 		{
 			name:  "empty string returns zero cursor",
 			input: "",
-			want:  modtimeCursor{},
+			want:  modTimeBlob.modtimeCursor{},
 		},
 		{
 			name:    "when no key is provided",
 			input:   "|borderlineSomethingSomething",
-			wantErr: errModTimeCursorEmptyKey,
+			wantErr: modTimeBlob.errModTimeCursorEmptyKey,
 		},
 		{
 			name:    "missing separator returns error",
 			input:   "nokeynoseparator",
-			wantErr: errModTimeCursorMissingSeparator,
+			wantErr: modTimeBlob.errModTimeCursorMissingSeparator,
 		},
 		{
 			name:    "non-integer unix-nano returns error",
 			input:   "somekey|notanumber",
-			wantErr: errModTimeCursorBadUnixNano,
+			wantErr: modTimeBlob.errModTimeCursorBadUnixNano,
 		},
 		{
 			name:  "valid cursor parses correctly",
 			input: "path/to/obj|1000000000",
-			want:  modtimeCursor{Key: "path/to/obj", ModTime: time.Unix(0, 1_000_000_000).UTC()},
+			want:  modTimeBlob.modtimeCursor{Key: "path/to/obj", ModTime: time.Unix(0, 1_000_000_000).UTC()},
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			c, err := parseModTimeCursor(tc.input)
+			c, err := modTimeBlob.parseModTimeCursor(tc.input)
 			if tc.wantErr != nil {
 				jtest.Require(t, tc.wantErr, err)
 				return
@@ -96,7 +97,7 @@ func TestParseModTimeCursor(t *testing.T) {
 }
 
 func TestModtimeCursor_RoundTrip(t *testing.T) {
-	original := modtimeCursor{
+	original := modTimeBlob.modtimeCursor{
 		Key:     "2024/01/15/event.json",
 		ModTime: time.Unix(1705276800, 123456789).UTC(),
 	}
@@ -104,7 +105,7 @@ func TestModtimeCursor_RoundTrip(t *testing.T) {
 	s := original.String()
 	require.NotEmpty(t, s)
 
-	parsed, err := parseModTimeCursor(s)
+	parsed, err := modTimeBlob.parseModTimeCursor(s)
 	jtest.RequireNil(t, err)
 	require.Equal(t, original, parsed)
 }

--- a/rblob/modTimeBlob_internal_test.go
+++ b/rblob/modTimeBlob_internal_test.go
@@ -1,7 +1,6 @@
 package rblob
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -186,7 +185,7 @@ func TestModtimeStream_ListSorted(t *testing.T) {
 
 	openBucket := func(t *testing.T, dir string) *blob.Bucket {
 		t.Helper()
-		b, err := blob.OpenBucket(context.Background(), "file:///"+dir)
+		b, err := blob.OpenBucket(t.Context(), "file:///"+dir)
 		require.NoError(t, err)
 		t.Cleanup(func() { require.NoError(t, b.Close()) })
 		return b
@@ -200,7 +199,7 @@ func TestModtimeStream_ListSorted(t *testing.T) {
 		writeFile(t, dir, "b-file", t2) // same modtime as c-file, but key sorts first
 		writeFile(t, dir, "d-file", t3) // latest
 
-		s := &modtimeStream{ctx: context.Background(), bucket: openBucket(t, dir)}
+		s := &modtimeStream{ctx: t.Context(), bucket: openBucket(t, dir)}
 		objs, err := s.listSorted()
 		require.NoError(t, err)
 		require.Len(t, objs, 4)
@@ -214,18 +213,18 @@ func TestModtimeStream_ListSorted(t *testing.T) {
 		dir := t.TempDir()
 		writeFile(t, dir, "other-obj", t1)
 
-		s := &modtimeStream{ctx: context.Background(), bucket: openBucket(t, dir), prefix: "nomatch/"}
+		s := &modtimeStream{ctx: t.Context(), bucket: openBucket(t, dir), prefix: "nomatch/"}
 		objs, err := s.listSorted()
 		require.NoError(t, err)
 		require.Empty(t, objs)
 	})
 
 	t.Run("closed bucket returns error", func(t *testing.T) {
-		b, err := blob.OpenBucket(context.Background(), "file:///"+t.TempDir())
+		b, err := blob.OpenBucket(t.Context(), "file:///"+t.TempDir())
 		require.NoError(t, err)
 		require.NoError(t, b.Close())
 
-		s := &modtimeStream{ctx: context.Background(), bucket: b}
+		s := &modtimeStream{ctx: t.Context(), bucket: b}
 		_, err = s.listSorted()
 		require.Error(t, err)
 	})
@@ -271,12 +270,12 @@ func TestModtimeStream_Close(t *testing.T) {
 		require.NoError(t, os.WriteFile(p, []byte(`{}`), 0o644))
 		require.NoError(t, os.Chtimes(p, t1, t1))
 
-		b, err := blob.OpenBucket(context.Background(), "file:///"+dir)
+		b, err := blob.OpenBucket(t.Context(), "file:///"+dir)
 		require.NoError(t, err)
 		t.Cleanup(func() { require.NoError(t, b.Close()) })
 
 		s := &modtimeStream{
-			ctx:         context.Background(),
+			ctx:         t.Context(),
 			bucket:      b,
 			decoderFunc: JSONDecoder,
 			backoff:     time.Millisecond,
@@ -287,7 +286,7 @@ func TestModtimeStream_Close(t *testing.T) {
 	})
 
 	t.Run("recv after close returns error", func(t *testing.T) {
-		s := &modtimeStream{ctx: context.Background()}
+		s := &modtimeStream{ctx: t.Context()}
 		require.NoError(t, s.Close())
 		_, err := s.Recv()
 		require.Error(t, err)

--- a/rblob/modTimeBlob_internal_test.go
+++ b/rblob/modTimeBlob_internal_test.go
@@ -1,6 +1,7 @@
 package rblob
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -12,6 +13,11 @@ import (
 	"gocloud.dev/blob"
 	_ "gocloud.dev/blob/fileblob"
 )
+
+// errDecoder is a Decoder that always returns a fixed error.
+type errDecoder struct{ err error }
+
+func (d *errDecoder) Decode() ([]byte, error) { return nil, d.err }
 
 func TestModtimeCursor_String(t *testing.T) {
 	tests := []struct {
@@ -291,4 +297,171 @@ func TestModtimeStream_Close(t *testing.T) {
 		_, err := s.Recv()
 		require.Error(t, err)
 	})
+}
+
+func TestModtimeEventType_ReflexType(t *testing.T) {
+	require.Equal(t, 0, modtimeEventType{}.ReflexType())
+}
+
+func TestNewModTimeBucket_Fallbacks(t *testing.T) {
+	b, err := blob.OpenBucket(t.Context(), "file:///"+t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, b.Close()) })
+
+	mb := NewModTimeBucket("test", b, WithModTimeDecoder(nil), WithModTimeBackoff(-1))
+	require.NotNil(t, mb.decoderFunc)
+	require.Equal(t, time.Minute, mb.backoff)
+}
+
+func TestModtimeStream_LoadNextObject_ListSortedError(t *testing.T) {
+	b, err := blob.OpenBucket(t.Context(), "file:///"+t.TempDir())
+	require.NoError(t, err)
+	require.NoError(t, b.Close())
+
+	s := &modtimeStream{
+		ctx:         t.Context(),
+		bucket:      b,
+		decoderFunc: JSONDecoder,
+		backoff:     time.Millisecond,
+	}
+	require.Error(t, s.loadNextObject())
+}
+
+func TestModtimeStream_LoadNextObject_NewReaderError(t *testing.T) {
+	b, err := blob.OpenBucket(t.Context(), "file:///"+t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, b.Close()) })
+
+	s := &modtimeStream{
+		ctx:         t.Context(),
+		bucket:      b,
+		decoderFunc: JSONDecoder,
+		backoff:     time.Millisecond,
+		objects:     []*blob.ListObject{{Key: "nonexistent", ModTime: time.Unix(1000, 0).UTC()}},
+	}
+	require.Error(t, s.loadNextObject())
+}
+
+func TestModtimeStream_LoadNextObject_DecoderFuncError(t *testing.T) {
+	dir := t.TempDir()
+	t1 := time.Unix(1000, 0).UTC()
+	p := filepath.Join(dir, "obj")
+	require.NoError(t, os.WriteFile(p, []byte(`{}`), 0o644))
+	require.NoError(t, os.Chtimes(p, t1, t1))
+
+	b, err := blob.OpenBucket(t.Context(), "file:///"+dir)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, b.Close()) })
+
+	decoderErr := errors.New("decoder failed")
+	s := &modtimeStream{
+		ctx:    t.Context(),
+		bucket: b,
+		decoderFunc: func(r io.Reader) (Decoder, error) {
+			return nil, decoderErr
+		},
+		backoff: time.Millisecond,
+	}
+	jtest.Require(t, decoderErr, s.loadNextObject())
+}
+
+func TestModtimeStream_LoadNextObject_DecodeFirstError(t *testing.T) {
+	dir := t.TempDir()
+	t1 := time.Unix(1000, 0).UTC()
+	p := filepath.Join(dir, "obj")
+	require.NoError(t, os.WriteFile(p, []byte(`not-valid-json`), 0o644))
+	require.NoError(t, os.Chtimes(p, t1, t1))
+
+	b, err := blob.OpenBucket(t.Context(), "file:///"+dir)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, b.Close()) })
+
+	s := &modtimeStream{
+		ctx:         t.Context(),
+		bucket:      b,
+		decoderFunc: JSONDecoder,
+		backoff:     time.Millisecond,
+	}
+	err = s.loadNextObject()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "decode first")
+}
+
+func TestModtimeStream_LoadNextObject_SkipOffsetExceedsBlob(t *testing.T) {
+	dir := t.TempDir()
+	t1 := time.Unix(1000, 0).UTC()
+	p := filepath.Join(dir, "obj")
+	require.NoError(t, os.WriteFile(p, []byte(`{"id":1}{"id":2}`), 0o644))
+	require.NoError(t, os.Chtimes(p, t1, t1))
+
+	b, err := blob.OpenBucket(t.Context(), "file:///"+dir)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, b.Close()) })
+
+	s := &modtimeStream{
+		ctx:         t.Context(),
+		bucket:      b,
+		decoderFunc: JSONDecoder,
+		backoff:     time.Millisecond,
+		cursor:      modtimeCursor{Key: "obj", ModTime: t1, Offset: 10},
+	}
+	require.NoError(t, s.loadNextObject())
+	require.True(t, s.blobEOF)
+}
+
+func TestModtimeStream_LoadNextObject_SkipRecordError(t *testing.T) {
+	dir := t.TempDir()
+	t1 := time.Unix(1000, 0).UTC()
+	p := filepath.Join(dir, "obj")
+	require.NoError(t, os.WriteFile(p, []byte(`{}`), 0o644))
+	require.NoError(t, os.Chtimes(p, t1, t1))
+
+	b, err := blob.OpenBucket(t.Context(), "file:///"+dir)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, b.Close()) })
+
+	skipErr := errors.New("skip failed")
+	s := &modtimeStream{
+		ctx:    t.Context(),
+		bucket: b,
+		decoderFunc: func(r io.Reader) (Decoder, error) {
+			return &errDecoder{err: skipErr}, nil
+		},
+		backoff: time.Millisecond,
+		cursor:  modtimeCursor{Key: "obj", ModTime: t1, Offset: 1},
+	}
+	jtest.Require(t, skipErr, s.loadNextObject())
+}
+
+func TestModtimeStream_Recv_DecodeErrorClosesReader(t *testing.T) {
+	dir := t.TempDir()
+	t1 := time.Unix(1000, 0).UTC()
+	p := filepath.Join(dir, "obj")
+	require.NoError(t, os.WriteFile(p, []byte(`{}`), 0o644))
+	require.NoError(t, os.Chtimes(p, t1, t1))
+
+	b, err := blob.OpenBucket(t.Context(), "file:///"+dir)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, b.Close()) })
+
+	r, err := b.NewReader(t.Context(), "obj", nil)
+	require.NoError(t, err)
+
+	decodeErr := errors.New("mid-stream decode error")
+	s := &modtimeStream{
+		ctx:     t.Context(),
+		bucket:  b,
+		backoff: time.Millisecond,
+		reader:  r,
+		decoder: &errDecoder{err: decodeErr},
+		next:    []byte(`{}`),
+		cursor:  modtimeCursor{Key: "obj", ModTime: t1},
+	}
+
+	_, err = s.Recv()
+	jtest.Require(t, decodeErr, err)
+
+	// Subsequent call returns the stored error.
+	_, err = s.Recv()
+	jtest.Require(t, decodeErr, err)
 }

--- a/rblob/modTimeBlob_internal_test.go
+++ b/rblob/modTimeBlob_internal_test.go
@@ -33,17 +33,22 @@ func TestModtimeCursor_String(t *testing.T) {
 		{
 			name:     "key with zero modtime",
 			cursor:   modtimeCursor{Key: "some/key", ModTime: time.Time{}},
-			expected: "some/key|-6795364578871345152",
+			expected: "some/key|-6795364578871345152|0",
 		},
 		{
 			name:     "key with positive unix-nano",
 			cursor:   modtimeCursor{Key: "a/b/c", ModTime: time.Unix(0, 1_000_000_000)},
-			expected: "a/b/c|1000000000",
+			expected: "a/b/c|1000000000|0",
 		},
 		{
 			name:     "key containing pipe character",
 			cursor:   modtimeCursor{Key: "file|with|pipes", ModTime: time.Unix(0, 42)},
-			expected: "file|with|pipes|42",
+			expected: "file|with|pipes|42|0",
+		},
+		{
+			name:     "non-zero offset is encoded",
+			cursor:   modtimeCursor{Key: "a/b/c", ModTime: time.Unix(0, 1_000_000_000), Offset: 3},
+			expected: "a/b/c|1000000000|3",
 		},
 	}
 
@@ -67,24 +72,34 @@ func TestParseModTimeCursor(t *testing.T) {
 			want:  modtimeCursor{},
 		},
 		{
-			name:    "when no key is provided",
-			input:   "|borderlineSomethingSomething",
-			wantErr: errModTimeCursorEmptyKey,
-		},
-		{
 			name:    "missing separator returns error",
 			input:   "nokeynoseparator",
 			wantErr: errModTimeCursorMissingSeparator,
 		},
 		{
+			name:    "only one separator returns error",
+			input:   "somekey|1000000000",
+			wantErr: errModTimeCursorMissingSeparator,
+		},
+		{
+			name:    "empty key returns error",
+			input:   "|1000000000|0",
+			wantErr: errModTimeCursorEmptyKey,
+		},
+		{
 			name:    "non-integer unix-nano returns error",
-			input:   "somekey|notanumber",
+			input:   "somekey|notanumber|0",
 			wantErr: errModTimeCursorBadUnixNano,
 		},
 		{
 			name:  "valid cursor parses correctly",
-			input: "path/to/obj|1000000000",
-			want:  modtimeCursor{Key: "path/to/obj", ModTime: time.Unix(0, 1_000_000_000).UTC()},
+			input: "path/to/obj|1000000000|5",
+			want:  modtimeCursor{Key: "path/to/obj", ModTime: time.Unix(0, 1_000_000_000).UTC(), Offset: 5},
+		},
+		{
+			name:    "non-integer offset returns error",
+			input:   "path/to/obj|1000000000|notanoffset",
+			wantErr: errModTimeCursorBadOffset,
 		},
 	}
 

--- a/rblob/modTimeBlob_internal_test.go
+++ b/rblob/modTimeBlob_internal_test.go
@@ -1,43 +1,48 @@
 package rblob
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/luno/jettison/errors"
 	"github.com/luno/jettison/jtest"
-	"github.com/luno/reflex/rblob/modTimeBlob"
 	"github.com/stretchr/testify/require"
+	"gocloud.dev/blob"
+	_ "gocloud.dev/blob/fileblob"
 )
 
 func TestModtimeCursor_String(t *testing.T) {
 	tests := []struct {
 		name     string
-		cursor   modTimeBlob.modtimeCursor
+		cursor   modtimeCursor
 		expected string
 	}{
 		{
 			name:     "empty key returns empty string",
-			cursor:   modTimeBlob.modtimeCursor{},
+			cursor:   modtimeCursor{},
 			expected: "",
 		},
 		{
 			name:     "empty key with non-zero modtime still returns empty string",
-			cursor:   modTimeBlob.modtimeCursor{Key: "", ModTime: time.Unix(0, 1234567890)},
+			cursor:   modtimeCursor{Key: "", ModTime: time.Unix(0, 1234567890)},
 			expected: "",
 		},
 		{
 			name:     "key with zero modtime",
-			cursor:   modTimeBlob.modtimeCursor{Key: "some/key", ModTime: time.Time{}},
+			cursor:   modtimeCursor{Key: "some/key", ModTime: time.Time{}},
 			expected: "some/key|-6795364578871345152",
 		},
 		{
 			name:     "key with positive unix-nano",
-			cursor:   modTimeBlob.modtimeCursor{Key: "a/b/c", ModTime: time.Unix(0, 1_000_000_000)},
+			cursor:   modtimeCursor{Key: "a/b/c", ModTime: time.Unix(0, 1_000_000_000)},
 			expected: "a/b/c|1000000000",
 		},
 		{
 			name:     "key containing pipe character",
-			cursor:   modTimeBlob.modtimeCursor{Key: "file|with|pipes", ModTime: time.Unix(0, 42)},
+			cursor:   modtimeCursor{Key: "file|with|pipes", ModTime: time.Unix(0, 42)},
 			expected: "file|with|pipes|42",
 		},
 	}
@@ -53,39 +58,39 @@ func TestParseModTimeCursor(t *testing.T) {
 	tests := []struct {
 		name    string
 		input   string
-		want    modTimeBlob.modtimeCursor
+		want    modtimeCursor
 		wantErr error
 	}{
 		{
 			name:  "empty string returns zero cursor",
 			input: "",
-			want:  modTimeBlob.modtimeCursor{},
+			want:  modtimeCursor{},
 		},
 		{
 			name:    "when no key is provided",
 			input:   "|borderlineSomethingSomething",
-			wantErr: modTimeBlob.errModTimeCursorEmptyKey,
+			wantErr: errModTimeCursorEmptyKey,
 		},
 		{
 			name:    "missing separator returns error",
 			input:   "nokeynoseparator",
-			wantErr: modTimeBlob.errModTimeCursorMissingSeparator,
+			wantErr: errModTimeCursorMissingSeparator,
 		},
 		{
 			name:    "non-integer unix-nano returns error",
 			input:   "somekey|notanumber",
-			wantErr: modTimeBlob.errModTimeCursorBadUnixNano,
+			wantErr: errModTimeCursorBadUnixNano,
 		},
 		{
 			name:  "valid cursor parses correctly",
 			input: "path/to/obj|1000000000",
-			want:  modTimeBlob.modtimeCursor{Key: "path/to/obj", ModTime: time.Unix(0, 1_000_000_000).UTC()},
+			want:  modtimeCursor{Key: "path/to/obj", ModTime: time.Unix(0, 1_000_000_000).UTC()},
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			c, err := modTimeBlob.parseModTimeCursor(tc.input)
+			c, err := parseModTimeCursor(tc.input)
 			if tc.wantErr != nil {
 				jtest.Require(t, tc.wantErr, err)
 				return
@@ -96,8 +101,123 @@ func TestParseModTimeCursor(t *testing.T) {
 	}
 }
 
+func TestModtimeStream_After(t *testing.T) {
+	t1 := time.Unix(1000, 0).UTC()
+	t2 := time.Unix(2000, 0).UTC()
+
+	tests := []struct {
+		name   string
+		cursor modtimeCursor
+		obj    *blob.ListObject
+		want   bool
+	}{
+		{
+			name:   "empty cursor is always after",
+			cursor: modtimeCursor{},
+			obj:    &blob.ListObject{Key: "any/key", ModTime: t1},
+			want:   true,
+		},
+		{
+			name:   "object modtime strictly after cursor",
+			cursor: modtimeCursor{Key: "a", ModTime: t1},
+			obj:    &blob.ListObject{Key: "a", ModTime: t2},
+			want:   true,
+		},
+		{
+			name:   "object modtime strictly before cursor",
+			cursor: modtimeCursor{Key: "b", ModTime: t2},
+			obj:    &blob.ListObject{Key: "b", ModTime: t1},
+			want:   false,
+		},
+		{
+			name:   "equal modtime key greater than cursor",
+			cursor: modtimeCursor{Key: "a", ModTime: t1},
+			obj:    &blob.ListObject{Key: "b", ModTime: t1},
+			want:   true,
+		},
+		{
+			name:   "equal modtime key equal to cursor",
+			cursor: modtimeCursor{Key: "a", ModTime: t1},
+			obj:    &blob.ListObject{Key: "a", ModTime: t1},
+			want:   false,
+		},
+		{
+			name:   "equal modtime key less than cursor",
+			cursor: modtimeCursor{Key: "b", ModTime: t1},
+			obj:    &blob.ListObject{Key: "a", ModTime: t1},
+			want:   false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &modtimeStream{cursor: tc.cursor}
+			require.Equal(t, tc.want, s.after(tc.obj))
+		})
+	}
+}
+
+func TestModtimeStream_ListSorted(t *testing.T) {
+	t1 := time.Unix(1000, 0).UTC()
+	t2 := time.Unix(2000, 0).UTC()
+	t3 := time.Unix(3000, 0).UTC()
+
+	writeFile := func(t *testing.T, dir, name string, modTime time.Time) {
+		t.Helper()
+		p := filepath.Join(dir, name)
+		require.NoError(t, os.WriteFile(p, []byte("{}"), 0o644))
+		require.NoError(t, os.Chtimes(p, modTime, modTime))
+	}
+
+	openBucket := func(t *testing.T, dir string) *blob.Bucket {
+		t.Helper()
+		b, err := blob.OpenBucket(context.Background(), "file:///"+dir)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, b.Close()) })
+		return b
+	}
+
+	t.Run("sorts by modtime then key", func(t *testing.T) {
+		dir := t.TempDir()
+		// Intentionally written out of order.
+		writeFile(t, dir, "c-file", t2) // ties with b-file on modtime
+		writeFile(t, dir, "a-file", t1) // earliest
+		writeFile(t, dir, "b-file", t2) // same modtime as c-file, but key sorts first
+		writeFile(t, dir, "d-file", t3) // latest
+
+		s := &modtimeStream{ctx: context.Background(), bucket: openBucket(t, dir)}
+		objs, err := s.listSorted()
+		require.NoError(t, err)
+		require.Len(t, objs, 4)
+		require.Equal(t, "a-file", objs[0].Key)
+		require.Equal(t, "b-file", objs[1].Key)
+		require.Equal(t, "c-file", objs[2].Key)
+		require.Equal(t, "d-file", objs[3].Key)
+	})
+
+	t.Run("no matching prefix returns empty slice", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, "other-obj", t1)
+
+		s := &modtimeStream{ctx: context.Background(), bucket: openBucket(t, dir), prefix: "nomatch/"}
+		objs, err := s.listSorted()
+		require.NoError(t, err)
+		require.Empty(t, objs)
+	})
+
+	t.Run("closed bucket returns error", func(t *testing.T) {
+		b, err := blob.OpenBucket(context.Background(), "file:///"+t.TempDir())
+		require.NoError(t, err)
+		require.NoError(t, b.Close())
+
+		s := &modtimeStream{ctx: context.Background(), bucket: b}
+		_, err = s.listSorted()
+		require.Error(t, err)
+	})
+}
+
 func TestModtimeCursor_RoundTrip(t *testing.T) {
-	original := modTimeBlob.modtimeCursor{
+	original := modtimeCursor{
 		Key:     "2024/01/15/event.json",
 		ModTime: time.Unix(1705276800, 123456789).UTC(),
 	}
@@ -105,7 +225,56 @@ func TestModtimeCursor_RoundTrip(t *testing.T) {
 	s := original.String()
 	require.NotEmpty(t, s)
 
-	parsed, err := modTimeBlob.parseModTimeCursor(s)
+	parsed, err := parseModTimeCursor(s)
 	jtest.RequireNil(t, err)
 	require.Equal(t, original, parsed)
+}
+
+func TestModtimeStream_Close(t *testing.T) {
+	t.Run("idle stream returns nil", func(t *testing.T) {
+		s := &modtimeStream{}
+		require.NoError(t, s.Close())
+	})
+
+	t.Run("already errored returns existing error", func(t *testing.T) {
+		sentinel := errors.New("existing error")
+		s := &modtimeStream{err: sentinel}
+		jtest.Require(t, sentinel, s.Close())
+	})
+
+	t.Run("second close returns error", func(t *testing.T) {
+		s := &modtimeStream{}
+		require.NoError(t, s.Close())
+		require.Error(t, s.Close())
+	})
+
+	t.Run("with open reader closes cleanly", func(t *testing.T) {
+		dir := t.TempDir()
+		t1 := time.Unix(1000, 0).UTC()
+
+		p := filepath.Join(dir, "obj")
+		require.NoError(t, os.WriteFile(p, []byte(`{}`), 0o644))
+		require.NoError(t, os.Chtimes(p, t1, t1))
+
+		b, err := blob.OpenBucket(context.Background(), "file:///"+dir)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, b.Close()) })
+
+		s := &modtimeStream{
+			ctx:         context.Background(),
+			bucket:      b,
+			decoderFunc: JSONDecoder,
+			backoff:     time.Millisecond,
+		}
+		require.NoError(t, s.loadNextObject())
+		require.NotNil(t, s.reader)
+		require.NoError(t, s.Close())
+	})
+
+	t.Run("recv after close returns error", func(t *testing.T) {
+		s := &modtimeStream{ctx: context.Background()}
+		require.NoError(t, s.Close())
+		_, err := s.Recv()
+		require.Error(t, err)
+	})
 }

--- a/rblob/modTimeBlob_test.go
+++ b/rblob/modTimeBlob_test.go
@@ -1,0 +1,182 @@
+package rblob_test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/luno/jettison/jtest"
+	"github.com/stretchr/testify/require"
+	"gocloud.dev/blob"
+	_ "gocloud.dev/blob/fileblob"
+
+	"github.com/luno/reflex/rblob"
+)
+
+func writeModTimeBlob(t *testing.T, dir, name string, content []byte, modTime time.Time) {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755))
+	require.NoError(t, os.WriteFile(p, content, 0o644))
+	require.NoError(t, os.Chtimes(p, modTime, modTime))
+}
+
+func openModTimeBucket(t *testing.T, dir string, opts ...rblob.BucketOption[rblob.ModTimeBucket]) *rblob.ModTimeBucket {
+	t.Helper()
+	b, err := blob.OpenBucket(context.Background(), "file:///"+dir)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, b.Close()) })
+	return rblob.NewModTimeBucket("test", b, opts...)
+}
+
+func TestModTimeStream_StreamsInModTimeOrder(t *testing.T) {
+	dir := t.TempDir()
+
+	t1 := time.Unix(1000, 0).UTC()
+	t2 := time.Unix(2000, 0).UTC()
+	t3 := time.Unix(3000, 0).UTC()
+
+	// Written out of lexicographic order; stream must reorder by mod time.
+	writeModTimeBlob(t, dir, "c-obj", []byte(`{"id":3}`), t3)
+	writeModTimeBlob(t, dir, "a-obj", []byte(`{"id":1}`), t1)
+	writeModTimeBlob(t, dir, "b-obj", []byte(`{"id":2}`), t2)
+
+	mb := openModTimeBucket(t, dir, rblob.WithModTimeBackoff(time.Millisecond))
+	sc, err := mb.ModTimeStream(context.Background(), "")
+	require.NoError(t, err)
+
+	for _, wantID := range []int64{1, 2, 3} {
+		e, err := sc.Recv()
+		jtest.Require(t, nil, err)
+
+		var got struct {
+			ID int64 `json:"id"`
+		}
+		require.NoError(t, json.Unmarshal(e.MetaData, &got))
+		require.Equal(t, wantID, got.ID)
+	}
+}
+
+func TestModTimeStream_Resume(t *testing.T) {
+	dir := t.TempDir()
+
+	t1 := time.Unix(1000, 0).UTC()
+	t2 := time.Unix(2000, 0).UTC()
+	t3 := time.Unix(3000, 0).UTC()
+
+	writeModTimeBlob(t, dir, "a-obj", []byte(`{"id":1}`), t1)
+	writeModTimeBlob(t, dir, "b-obj", []byte(`{"id":2}`), t2)
+	writeModTimeBlob(t, dir, "c-obj", []byte(`{"id":3}`), t3)
+
+	mb := openModTimeBucket(t, dir, rblob.WithModTimeBackoff(time.Millisecond))
+
+	// Stream the first event and capture its cursor.
+	sc, err := mb.ModTimeStream(context.Background(), "")
+	require.NoError(t, err)
+
+	first, err := sc.Recv()
+	jtest.Require(t, nil, err)
+	afterCursor := first.ID
+
+	// A fresh stream resuming after the first event should only yield b-obj and c-obj.
+	sc2, err := mb.ModTimeStream(context.Background(), afterCursor)
+	require.NoError(t, err)
+
+	for _, wantID := range []int64{2, 3} {
+		e, err := sc2.Recv()
+		jtest.Require(t, nil, err)
+
+		var got struct {
+			ID int64 `json:"id"`
+		}
+		require.NoError(t, json.Unmarshal(e.MetaData, &got))
+		require.Equal(t, wantID, got.ID)
+	}
+}
+
+func TestModTimeStream_WithPrefix(t *testing.T) {
+	dir := t.TempDir()
+
+	t1 := time.Unix(1000, 0).UTC()
+	t2 := time.Unix(2000, 0).UTC()
+
+	writeModTimeBlob(t, dir, "other-obj", []byte(`{"id":99}`), t1)
+	writeModTimeBlob(t, dir, filepath.Join("prefix", "a-obj"), []byte(`{"id":1}`), t1)
+	writeModTimeBlob(t, dir, filepath.Join("prefix", "b-obj"), []byte(`{"id":2}`), t2)
+
+	mb := openModTimeBucket(t, dir,
+		rblob.WithModTimePrefix("prefix."),
+		rblob.WithModTimeBackoff(time.Millisecond),
+	)
+
+	sc, err := mb.ModTimeStream(context.Background(), "")
+	require.NoError(t, err)
+
+	for _, wantID := range []int64{1, 2} {
+		e, err := sc.Recv()
+		jtest.Require(t, nil, err)
+
+		var got struct {
+			ID int64 `json:"id"`
+		}
+		require.NoError(t, json.Unmarshal(e.MetaData, &got))
+		require.Equal(t, wantID, got.ID)
+	}
+}
+
+func TestModTimeStream_ContextCancel(t *testing.T) {
+	dir := t.TempDir()
+
+	mb := openModTimeBucket(t, dir, rblob.WithModTimeBackoff(time.Hour))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	sc, err := mb.ModTimeStream(ctx, "")
+	require.NoError(t, err)
+
+	_, err = sc.Recv()
+	jtest.Require(t, context.DeadlineExceeded, err)
+}
+
+func TestModTimeBucket_Close(t *testing.T) {
+	dir := t.TempDir()
+	b, err := blob.OpenBucket(context.Background(), "file:///"+dir)
+	require.NoError(t, err)
+
+	mb := rblob.NewModTimeBucket("test", b)
+	require.NoError(t, mb.Close())
+}
+
+func TestModTimeStream_MultipleEventsPerFile(t *testing.T) {
+	dir := t.TempDir()
+
+	t1 := time.Unix(1000, 0).UTC()
+	writeModTimeBlob(t, dir, "multi", []byte(`{"id":1}{"id":2}{"id":3}`), t1)
+
+	mb := openModTimeBucket(t, dir, rblob.WithModTimeBackoff(time.Millisecond))
+	sc, err := mb.ModTimeStream(context.Background(), "")
+	require.NoError(t, err)
+
+	var ids []int64
+	var cursorIDs []string
+	for range 3 {
+		e, err := sc.Recv()
+		jtest.Require(t, nil, err)
+
+		var got struct {
+			ID int64 `json:"id"`
+		}
+		require.NoError(t, json.Unmarshal(e.MetaData, &got))
+		ids = append(ids, got.ID)
+		cursorIDs = append(cursorIDs, e.ID)
+	}
+
+	require.Equal(t, []int64{1, 2, 3}, ids)
+	// All records in the same file share the same cursor (the file's key + modtime).
+	require.Equal(t, cursorIDs[0], cursorIDs[1])
+	require.Equal(t, cursorIDs[0], cursorIDs[2])
+}

--- a/rblob/modTimeBlob_test.go
+++ b/rblob/modTimeBlob_test.go
@@ -108,7 +108,7 @@ func TestModTimeStream_WithPrefix(t *testing.T) {
 	writeModTimeBlob(t, dir, filepath.Join("prefix", "b-obj"), []byte(`{"id":2}`), t2)
 
 	mb := openModTimeBucket(t, dir,
-		rblob.WithModTimePrefix("prefix."),
+		rblob.WithModTimePrefix("prefix/"),
 		rblob.WithModTimeBackoff(time.Millisecond),
 	)
 

--- a/rblob/modTimeBlob_test.go
+++ b/rblob/modTimeBlob_test.go
@@ -26,7 +26,7 @@ func writeModTimeBlob(t *testing.T, dir, name string, content []byte, modTime ti
 
 func openModTimeBucket(t *testing.T, dir string, opts ...rblob.BucketOption[rblob.ModTimeBucket]) *rblob.ModTimeBucket {
 	t.Helper()
-	b, err := blob.OpenBucket(context.Background(), "file:///"+dir)
+	b, err := blob.OpenBucket(t.Context(), "file:///"+dir)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, b.Close()) })
 	return rblob.NewModTimeBucket("test", b, opts...)
@@ -45,7 +45,7 @@ func TestModTimeStream_StreamsInModTimeOrder(t *testing.T) {
 	writeModTimeBlob(t, dir, "b-obj", []byte(`{"id":2}`), t2)
 
 	mb := openModTimeBucket(t, dir, rblob.WithModTimeBackoff(time.Millisecond))
-	sc, err := mb.ModTimeStream(context.Background(), "")
+	sc, err := mb.ModTimeStream(t.Context(), "")
 	require.NoError(t, err)
 
 	for _, wantID := range []int64{1, 2, 3} {
@@ -74,7 +74,7 @@ func TestModTimeStream_Resume(t *testing.T) {
 	mb := openModTimeBucket(t, dir, rblob.WithModTimeBackoff(time.Millisecond))
 
 	// Stream the first event and capture its cursor.
-	sc, err := mb.ModTimeStream(context.Background(), "")
+	sc, err := mb.ModTimeStream(t.Context(), "")
 	require.NoError(t, err)
 
 	first, err := sc.Recv()
@@ -82,7 +82,7 @@ func TestModTimeStream_Resume(t *testing.T) {
 	afterCursor := first.ID
 
 	// A fresh stream resuming after the first event should only yield b-obj and c-obj.
-	sc2, err := mb.ModTimeStream(context.Background(), afterCursor)
+	sc2, err := mb.ModTimeStream(t.Context(), afterCursor)
 	require.NoError(t, err)
 
 	for _, wantID := range []int64{2, 3} {
@@ -112,7 +112,7 @@ func TestModTimeStream_WithPrefix(t *testing.T) {
 		rblob.WithModTimeBackoff(time.Millisecond),
 	)
 
-	sc, err := mb.ModTimeStream(context.Background(), "")
+	sc, err := mb.ModTimeStream(t.Context(), "")
 	require.NoError(t, err)
 
 	for _, wantID := range []int64{1, 2} {
@@ -132,7 +132,7 @@ func TestModTimeStream_ContextCancel(t *testing.T) {
 
 	mb := openModTimeBucket(t, dir, rblob.WithModTimeBackoff(time.Hour))
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Millisecond)
 	defer cancel()
 
 	sc, err := mb.ModTimeStream(ctx, "")
@@ -144,7 +144,7 @@ func TestModTimeStream_ContextCancel(t *testing.T) {
 
 func TestModTimeBucket_Close(t *testing.T) {
 	dir := t.TempDir()
-	b, err := blob.OpenBucket(context.Background(), "file:///"+dir)
+	b, err := blob.OpenBucket(t.Context(), "file:///"+dir)
 	require.NoError(t, err)
 
 	mb := rblob.NewModTimeBucket("test", b)
@@ -158,7 +158,7 @@ func TestModTimeStream_MultipleEventsPerFile(t *testing.T) {
 	writeModTimeBlob(t, dir, "multi", []byte(`{"id":1}{"id":2}{"id":3}`), t1)
 
 	mb := openModTimeBucket(t, dir, rblob.WithModTimeBackoff(time.Millisecond))
-	sc, err := mb.ModTimeStream(context.Background(), "")
+	sc, err := mb.ModTimeStream(t.Context(), "")
 	require.NoError(t, err)
 
 	var ids []int64
@@ -189,7 +189,7 @@ func TestModTimeStream_ResumeFromMiddleOfBlob(t *testing.T) {
 
 	mb := openModTimeBucket(t, dir, rblob.WithModTimeBackoff(time.Millisecond))
 
-	sc, err := mb.ModTimeStream(context.Background(), "")
+	sc, err := mb.ModTimeStream(t.Context(), "")
 	require.NoError(t, err)
 
 	first, err := sc.Recv()
@@ -201,7 +201,7 @@ func TestModTimeStream_ResumeFromMiddleOfBlob(t *testing.T) {
 	require.Equal(t, int64(1), got.ID)
 
 	// Resume after the first record — should yield records 2 and 3 only.
-	sc2, err := mb.ModTimeStream(context.Background(), first.ID)
+	sc2, err := mb.ModTimeStream(t.Context(), first.ID)
 	require.NoError(t, err)
 
 	for _, wantID := range []int64{2, 3} {

--- a/rblob/modTimeBlob_test.go
+++ b/rblob/modTimeBlob_test.go
@@ -3,6 +3,7 @@ package rblob_test
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -13,6 +14,7 @@ import (
 	"gocloud.dev/blob"
 	_ "gocloud.dev/blob/fileblob"
 
+	"github.com/luno/reflex"
 	"github.com/luno/reflex/rblob"
 )
 
@@ -211,4 +213,54 @@ func TestModTimeStream_ResumeFromMiddleOfBlob(t *testing.T) {
 		require.NoError(t, json.Unmarshal(e.MetaData, &got))
 		require.Equal(t, wantID, got.ID)
 	}
+}
+
+func TestOpenModTimeBucket_FileURL(t *testing.T) {
+	dir := t.TempDir()
+	mb, err := rblob.OpenModTimeBucket(t.Context(), "test", "file:///"+dir)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, mb.Close()) })
+	require.NotNil(t, mb)
+}
+
+func TestOpenModTimeBucket_InvalidURLReturnsError(t *testing.T) {
+	_, err := rblob.OpenModTimeBucket(t.Context(), "test", "invalid-scheme://bucket")
+	require.Error(t, err)
+}
+
+func TestModTimeStream_OptionsNotSupported(t *testing.T) {
+	dir := t.TempDir()
+	mb := openModTimeBucket(t, dir)
+	_, err := mb.ModTimeStream(t.Context(), "", reflex.WithStreamToHead())
+	require.Error(t, err)
+}
+
+func TestModTimeStream_InvalidCursorReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	mb := openModTimeBucket(t, dir)
+	_, err := mb.ModTimeStream(t.Context(), "no-separator-here")
+	require.Error(t, err)
+}
+
+func TestWithModTimeDecoder_CustomDecoder(t *testing.T) {
+	dir := t.TempDir()
+	t1 := time.Unix(1000, 0).UTC()
+	writeModTimeBlob(t, dir, "obj", []byte(`{"id":1}`), t1)
+
+	called := false
+	customDecoder := func(r io.Reader) (rblob.Decoder, error) {
+		called = true
+		return rblob.JSONDecoder(r)
+	}
+
+	mb := openModTimeBucket(t, dir,
+		rblob.WithModTimeDecoder(customDecoder),
+		rblob.WithModTimeBackoff(time.Millisecond),
+	)
+	sc, err := mb.ModTimeStream(t.Context(), "")
+	require.NoError(t, err)
+
+	_, err = sc.Recv()
+	jtest.Require(t, nil, err)
+	require.True(t, called)
 }

--- a/rblob/modTimeBlob_test.go
+++ b/rblob/modTimeBlob_test.go
@@ -176,7 +176,39 @@ func TestModTimeStream_MultipleEventsPerFile(t *testing.T) {
 	}
 
 	require.Equal(t, []int64{1, 2, 3}, ids)
-	// All records in the same file share the same cursor (the file's key + modtime).
-	require.Equal(t, cursorIDs[0], cursorIDs[1])
-	require.Equal(t, cursorIDs[0], cursorIDs[2])
+	// Each record in the same file gets a unique cursor with an incrementing offset.
+	require.NotEqual(t, cursorIDs[0], cursorIDs[1])
+	require.NotEqual(t, cursorIDs[1], cursorIDs[2])
+}
+
+func TestModTimeStream_ResumeFromMiddleOfBlob(t *testing.T) {
+	dir := t.TempDir()
+
+	t1 := time.Unix(1000, 0).UTC()
+	writeModTimeBlob(t, dir, "multi", []byte(`{"id":1}{"id":2}{"id":3}`), t1)
+
+	mb := openModTimeBucket(t, dir, rblob.WithModTimeBackoff(time.Millisecond))
+
+	sc, err := mb.ModTimeStream(context.Background(), "")
+	require.NoError(t, err)
+
+	first, err := sc.Recv()
+	jtest.Require(t, nil, err)
+	var got struct {
+		ID int64 `json:"id"`
+	}
+	require.NoError(t, json.Unmarshal(first.MetaData, &got))
+	require.Equal(t, int64(1), got.ID)
+
+	// Resume after the first record — should yield records 2 and 3 only.
+	sc2, err := mb.ModTimeStream(context.Background(), first.ID)
+	require.NoError(t, err)
+
+	for _, wantID := range []int64{2, 3} {
+		e, err := sc2.Recv()
+		jtest.Require(t, nil, err)
+
+		require.NoError(t, json.Unmarshal(e.MetaData, &got))
+		require.Equal(t, wantID, got.ID)
+	}
 }

--- a/rblob/s3_test.go
+++ b/rblob/s3_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	_ "gocloud.dev/blob/s3blob" // Driver for test
@@ -16,6 +17,11 @@ import (
 var (
 	s3url   = flag.String("test_s3_url", "", "Define to enable s3 integration test")
 	s3after = flag.String("test_s3_after", "", "Define to stream after this event id")
+
+	modTimeS3URL    = flag.String("test_modtime_s3_url", "", "Define to enable modtime s3 integration test")
+	modTimeS3After  = flag.String("test_modtime_s3_after", "", "Modtime cursor to resume streaming from")
+	modTimeS3Prefix = flag.String("test_modtime_s3_prefix", "prefix", "Optional key prefix filter for modtime s3 test")
+	modTimeS3Date   = flag.String("test_modtime_s3_date", "", "Date in YYYYMMDD format for date-prefix subtest (defaults to today UTC)")
 )
 
 // TestS3 provides an integration test for streaming json events from a s3 bucket. It prints
@@ -52,4 +58,72 @@ func TestS3(t *testing.T) {
 		fmt.Println(e.ID)
 		fmt.Printf("%s\n\n", e.MetaData)
 	}
+}
+
+// TestModTimeS3 provides an integration test for streaming json events from an S3 bucket
+// ordered by last-modified time. It prints event ids and metadata. AWS credentials are
+// obtained from the environment.
+//
+// Run a specific subtest with -run TestModTimeS3/<name>. Each subtest streams indefinitely.
+//
+// Usage:
+//
+//	export URL="s3://my_bucket"
+//	go test github.com/luno/reflex/rblob -v -run TestModTimeS3/stream_with_prefix \
+//	  -test_modtime_s3_url="$URL" \
+//	  -test_modtime_s3_after="$AFTER_ID" \
+//	  -test_modtime_s3_prefix="some/path/"
+//
+//	go test github.com/luno/reflex/rblob -v -run TestModTimeS3/stream_with_date_prefix \
+//	  -test_modtime_s3_url="$URL" \
+//	  -test_modtime_s3_after="$AFTER_ID" \
+//	  -test_modtime_s3_date="20260529"
+func TestModTimeS3(t *testing.T) {
+	if *modTimeS3URL == "" {
+		t.Skip("Skipping modtime s3 integration test, test_modtime_s3_url flag empty.")
+		return
+	}
+
+	if !strings.HasPrefix(*modTimeS3URL, "s3://") {
+		t.Errorf("test_modtime_s3_url requires 's3://' prefix")
+		return
+	}
+
+	ctx := context.Background()
+
+	openBucket := func(t *testing.T, opts ...rblob.BucketOption[rblob.ModTimeBucket]) *rblob.ModTimeBucket {
+		t.Helper()
+		b, err := rblob.OpenModTimeBucket(ctx, "s3-modtime-test", *modTimeS3URL, opts...)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, b.Close()) })
+		return b
+	}
+
+	stream := func(t *testing.T, b *rblob.ModTimeBucket) {
+		t.Helper()
+		sc, err := b.ModTimeStream(ctx, *modTimeS3After)
+		require.NoError(t, err)
+		for {
+			e, err := sc.Recv()
+			require.NoError(t, err)
+			fmt.Println(e.ID)
+			fmt.Printf("%s\n\n", e.MetaData)
+		}
+	}
+
+	t.Run("stream with prefix", func(t *testing.T) {
+		var opts []rblob.BucketOption[rblob.ModTimeBucket]
+		if *modTimeS3Prefix != "" {
+			opts = append(opts, rblob.WithModTimePrefix(*modTimeS3Prefix))
+		}
+		stream(t, openBucket(t, opts...))
+	})
+
+	t.Run("stream with date prefix", func(t *testing.T) {
+		date := *modTimeS3Date
+		if date == "" {
+			date = time.Now().UTC().Format("20060502")
+		}
+		stream(t, openBucket(t, rblob.WithModTimePrefix(date+".")))
+	})
 }

--- a/rblob/s3_test.go
+++ b/rblob/s3_test.go
@@ -20,7 +20,7 @@ var (
 
 	modTimeS3URL    = flag.String("test_modtime_s3_url", "", "Define to enable modtime s3 integration test")
 	modTimeS3After  = flag.String("test_modtime_s3_after", "", "Modtime cursor to resume streaming from")
-	modTimeS3Prefix = flag.String("test_modtime_s3_prefix", "prefix", "Optional key prefix filter for modtime s3 test")
+	modTimeS3Prefix = flag.String("test_modtime_s3_prefix", "", "Optional key prefix filter for modtime s3 test")
 	modTimeS3Date   = flag.String("test_modtime_s3_date", "", "Date in YYYYMMDD format for date-prefix subtest (defaults to today UTC)")
 )
 

--- a/rblob/utils.go
+++ b/rblob/utils.go
@@ -7,3 +7,6 @@ type Decoder interface {
 	// are available.
 	Decode() ([]byte, error)
 }
+
+// BucketOption is a generic functional option that configures a bucket of type T.
+type BucketOption[T any] func(*T)

--- a/rblob/utils.go
+++ b/rblob/utils.go
@@ -1,0 +1,9 @@
+package rblob
+
+// Decoder decodes a blob into event byte slices (usually DTOs) which
+// are streamed as event metadata.
+type Decoder interface {
+	// Decode returns the next non-empty byte slice or an error. It returns io.EOF if no more
+	// are available.
+	Decode() ([]byte, error)
+}


### PR DESCRIPTION
## For External Submissions:

Adding ModTimeStream and ModTimeBucket to allow for S3 bucket to read all objects (filtered by prefix) that are ordered by last modified time and processed in ordered queue. 

This work addresses issue #94 and unit tests are included

## Summary of how ModTimeBlob works:
### Receiving an event (Recv)
  
  Each call to Recv goes through recv, which follows this loop:

  recv()
    └─ while no active blob (decoder==nil or blobEOF)
         └─ loadNextObject()
    └─ emit one event from current blob

 ### loadNextObject does the heavy lifting:

  1. Closes the previous blob reader if one is open.
  2. Refills the object list if exhausted — calls listSorted(), which fetches all objects matching the prefix and
  sorts them by (ModTime ASC, Key ASC).
  3. Skips objects at or before the cursor via after(), with one exception: if resumeDone=false and Offset>0 and
  the object is the cursor blob (isCursorBlob), it stops skipping to allow a mid-blob resume.
  4. Polls (with backoff) if no new objects exist yet.
  5. Opens the next object's reader and decoder.
  6. Mid-blob resume: if this is the cursor blob, decodes and discards the first Offset records (already-consumed),
  then sets resumeDone=true. Otherwise resets the cursor to {Key, ModTime, Offset:0}.
  7. Pre-fetches the first record into s.next.

### Back in recv, once a blob is active:

  1. Takes s.next as the payload.
  2. Peeks ahead — decodes the next record. If EOF, sets blobEOF=true so the next Recv call will advance to the
  next blob.
  3. Increments s.cursor.Offset.
  4. Emits a reflex.Event with ID = "key|nano|offset", Timestamp = ModTime, MetaData = payload.

 ### Cursor and resume
  
  The event ID is the serialised cursor: "events/2024.json|1700000000000000000|2". A consumer stores the last-seen
  ID and passes it back as after on restart. The stream then:

  - Skips all blobs strictly before that cursor (by ModTime, then Key).
  - Re-opens the cursor blob and discards the first Offset records.
  - Resumes emitting from record Offset+1 onwards.

---

- [x] Have you followed the guidelines in our [Contributing](https://github.com/luno/.github/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [x] If it's a non-trivial change, I've linked a new or existing [issue](../issues) to this PR
- [x] I have performed a self-review of my code
- [x] Does your submission pass existing tests?
- [x] Have you written new tests for your new changes, if applicable?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stream objects ordered by modification time with resumable cursors, prefix filtering, configurable backoff, and per-record event timestamps with stable ordering.

* **Public API**
  * Added a Decoder abstraction and a generic BucketOption type to configure buckets and decoders; new ModTimeBucket and stream entry points exposed.

* **Tests**
  * Added extensive unit and integration tests covering ordering, resumption, prefix filtering, multi-record handling and S3 integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->