### PR TITLE
Adding error details to modTimeBlob for debugging

### DIFF
--- a/rblob/errors.go
+++ b/rblob/errors.go
@@ -1,0 +1,10 @@
+package rblob
+
+import "github.com/luno/jettison/errors"
+
+var (
+	errModTimeCursorMissingSeparator = errors.New("invalid modtime cursor: missing separator")
+	errModTimeCursorEmptyKey         = errors.New("invalid modtime cursor: empty key")
+	errModTimeCursorBadUnixNano      = errors.New("invalid modtime cursor: bad unix-nano")
+	errModTimeCursorBadOffset        = errors.New("invalid modtime cursor: bad offset")
+)

--- a/rblob/modTimeBlob.go
+++ b/rblob/modTimeBlob.go
@@ -186,11 +186,11 @@ func parseModTimeCursor(s string) (modtimeCursor, error) {
 	}
 	ns, err := strconv.ParseInt(nanoStr, 10, 64)
 	if err != nil {
-		return modtimeCursor{}, errors.Wrap(errModTimeCursorBadUnixNano, "", j.MKV{"cursor": s, "ns": ns})
+		return modtimeCursor{}, errors.Wrap(errModTimeCursorBadUnixNano, "", j.MKV{"cursor": s, "nanoStr": nanoStr})
 	}
 	offset, err := strconv.ParseInt(tail, 10, 64)
 	if err != nil {
-		return modtimeCursor{}, errors.Wrap(errModTimeCursorBadOffset, "", j.MKV{"cursor": s, "offset": offset})
+		return modtimeCursor{}, errors.Wrap(errModTimeCursorBadOffset, "", j.MKV{"cursor": s, "tail": tail})
 	}
 	return modtimeCursor{
 		Key:     key,

--- a/rblob/modTimeBlob.go
+++ b/rblob/modTimeBlob.go
@@ -24,13 +24,6 @@ import (
 // the last modified list objects to determine its resume position.
 // --------------------------------------------------------------------------------------------
 
-var (
-	errModTimeCursorMissingSeparator = errors.New("invalid modtime cursor: missing separator")
-	errModTimeCursorEmptyKey         = errors.New("invalid modtime cursor: empty key")
-	errModTimeCursorBadUnixNano      = errors.New("invalid modtime cursor: bad unix-nano")
-	errModTimeCursorBadOffset        = errors.New("invalid modtime cursor: bad offset")
-)
-
 // WithModTimeBackoff configures the backoff duration between polls when no new
 // objects are found. Defaults to one minute.
 func WithModTimeBackoff(d time.Duration) BucketOption[ModTimeBucket] {
@@ -166,9 +159,6 @@ func (c modtimeCursor) String() string {
 // where modtime_unix_nano is a Unix timestamp in nanoseconds and offset is the
 // number of records already consumed from this blob.
 //
-// The legacy two-part format <key>|<modtime_unix_nano> is also accepted and
-// returns a cursor with Offset 0.
-//
 // An empty string returns an empty modtimeCursor and no error.
 // An error is returned if the cursor format is invalid or fields cannot be parsed.
 func parseModTimeCursor(s string) (modtimeCursor, error) {
@@ -178,7 +168,7 @@ func parseModTimeCursor(s string) (modtimeCursor, error) {
 
 	lastSep := strings.LastIndex(s, "|")
 	if lastSep < 0 {
-		return modtimeCursor{}, errors.Wrap(errModTimeCursorMissingSeparator, "")
+		return modtimeCursor{}, errors.Wrap(errModTimeCursorMissingSeparator, "", j.MKV{"cursor": s, "lastSep": lastSep})
 	}
 
 	tail := s[lastSep+1:]
@@ -186,21 +176,21 @@ func parseModTimeCursor(s string) (modtimeCursor, error) {
 
 	secondSep := strings.LastIndex(prefix, "|")
 	if secondSep < 0 {
-		return modtimeCursor{}, errors.Wrap(errModTimeCursorMissingSeparator, "")
+		return modtimeCursor{}, errors.Wrap(errModTimeCursorMissingSeparator, "", j.MKV{"cursor": s, "secondSep": secondSep, "prefix": prefix})
 	}
 
 	key := prefix[:secondSep]
 	nanoStr := prefix[secondSep+1:]
 	if key == "" {
-		return modtimeCursor{}, errors.Wrap(errModTimeCursorEmptyKey, "")
+		return modtimeCursor{}, errors.Wrap(errModTimeCursorEmptyKey, "", j.MKV{"cursor": s, "nanoStr": nanoStr})
 	}
 	ns, err := strconv.ParseInt(nanoStr, 10, 64)
 	if err != nil {
-		return modtimeCursor{}, errors.Wrap(errModTimeCursorBadUnixNano, "")
+		return modtimeCursor{}, errors.Wrap(errModTimeCursorBadUnixNano, "", j.MKV{"cursor": s, "ns": ns})
 	}
 	offset, err := strconv.ParseInt(tail, 10, 64)
 	if err != nil {
-		return modtimeCursor{}, errors.Wrap(errModTimeCursorBadOffset, "")
+		return modtimeCursor{}, errors.Wrap(errModTimeCursorBadOffset, "", j.MKV{"cursor": s, "offset": offset})
 	}
 	return modtimeCursor{
 		Key:     key,


### PR DESCRIPTION
## For External Submissions:

- Adding error details to modTimeBlob for debugging
- Fixed commenting documentation

Part of addressing issue #94 
---

- [x] Have you followed the guidelines in our [Contributing](https://github.com/luno/.github/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [x] If it's a non-trivial change, I've linked a new or existing [issue](../issues) to this PR
- [x] I have performed a self-review of my code
- [x] Does your submission pass existing tests?
- [x] Have you written new tests for your new changes, if applicable?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error diagnostics for modtime cursor parsing failures, providing richer diagnostic metadata to aid troubleshooting and issue resolution.

* **Documentation**
  * Removed documentation for the legacy two-part cursor format that is no longer supported by the system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->